### PR TITLE
K8S-435 Create build of the amphora image and artifact it for use

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ security patches, etc. Refer to [Building Octavia Iamges](https://docs.openstack
 
 2. Install RPC-O as an AIO
 
-    sudo add-apt-repository ppa:canonical-kernel-team/ppa
+    add-apt-repository ppa:canonical-kernel-team/ppa
+    add-apt-repository ppa:ubuntu-toolchain-r/ppa
     cd /opt
     git clone --recursive -b  newton https://github.com/rcbops/rpc-openstack.git
     cd rpc-openstack/
@@ -57,3 +58,21 @@ security patches, etc. Refer to [Building Octavia Iamges](https://docs.openstack
     ./scripts/deploy.sh
 
 4. Build, upload and tag an amphora image *before* you can use Octavia
+
+### Run tests (post gate)
+1. Update the host to the latest packages
+
+    apt-get update && apt-get -y dist-upgrade && reboot
+
+2. Prepare tests (this might go away eventually)
+
+    add-apt-repository ppa:canonical-kernel-team/ppa
+    add-apt-repository ppa:ubuntu-toolchain-r/ppa
+    cd /opt
+    git clone https://github.com/rcbops/rpc-octavia.git
+    cd rpc-octavia
+
+3. Run tests
+    ./gating/[pre_merge_test|post_merge_test]/[pre|run|post]
+
+

--- a/gating/post_merge_test/build_amphora_image.sh
+++ b/gating/post_merge_test/build_amphora_image.sh
@@ -1,0 +1,1 @@
+../scripts/test_and_push_image.sh

--- a/gating/post_merge_test/post
+++ b/gating/post_merge_test/post
@@ -1,0 +1,1 @@
+../scripts/post.sh

--- a/gating/post_merge_test/pre
+++ b/gating/post_merge_test/pre
@@ -1,0 +1,1 @@
+../scripts/pre.sh

--- a/gating/post_merge_test/run
+++ b/gating/post_merge_test/run
@@ -1,0 +1,1 @@
+../scripts/run.sh

--- a/gating/pre_merge_test/pre
+++ b/gating/pre_merge_test/pre
@@ -1,0 +1,1 @@
+../scripts/pre.sh

--- a/gating/pre_merge_test/run
+++ b/gating/pre_merge_test/run
@@ -1,0 +1,1 @@
+../scripts/run.sh

--- a/gating/scripts/amphora-image-push-to-mirror.yml
+++ b/gating/scripts/amphora-image-push-to-mirror.yml
@@ -1,0 +1,44 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This playbook's function is to upload the amp image
+
+- name: Push the git artifacts to rpc-repo
+  hosts: mirrors
+  vars:
+    src_amp_archive_dir: "{{ working_dir }}/amp-image/{{ rpc_release }}/amphora-x64-haproxy.qcow2"
+    dst_amp_archive_dir: "/var/www/repo/images/amphora/{{ rpc_release }}/{{ git_sha }}"
+  tasks:
+
+    - name: Ensure amp image archive directory exists
+      file:
+        path: "{{ dst_amp_archive_dir }}"
+        state: directory
+        owner: "nginx"
+        group: "www-data"
+
+    - name: Push updated amp image to rpc-repo
+      synchronize:
+        src: "{{ src_amp_archive_dir }}"
+        dest: "{{ dst_amp_archive_dir }}/"
+        mode: push
+        delete: yes
+        recursive: yes
+        rsync_opts:
+          - "--chown=nginx:www-data"
+      register: synchronize
+      until: synchronize | success
+      retries: 5
+      delay: 5

--- a/gating/scripts/post.sh
+++ b/gating/scripts/post.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Copyright 2014-2017 , Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## Shell Opts ----------------------------------------------------------------
+set -xeuo pipefail
+
+## Vars ----------------------------------------------------------------------
+source /opt/rpc-octavia/gating/scripts/vars.sh
+
+## Main ----------------------------------------------------------------------
+function amp_image_artifacts_available {
+
+    CHECK_URL="${HOST_RCBOPS_REPO}/images/amphora/${RPC_RELEASE}/${GIT_SHA}/amphora-x64-haproxy.qcow2"
+    LOCAL_FILE="${MY_BASE_DIR}/amp-image/${RPC_RELEASE}/amphora-x64-haproxy.qcow2"
+
+    # Does the file exist?
+    if curl --output /dev/null --silent --head --fail ${CHECK_URL}; then
+        # Check if the files are the same. Operating System might have had changes
+        online_md5=$(curl -s $CHECK_URL | md5sum | awk '{print $1}')
+        local_md5=$(md5sum "${LOCAL_FILE}" | awk '{print $1}')
+
+        if [ "$online_md5" == "$local_md5" ]; then
+            return 0
+        else
+            return 1
+        fi
+    else
+        return 1
+    fi
+
+}
+
+echo "Post gate job started"
+echo "+-------------------- START ENV VARS --------------------+"
+env
+echo "+-------------------- START ENV VARS --------------------+"
+
+# We use the sha to determine which folder to put things in
+export GIT_SHA=$(cd ${OCTAVIA_TEMP_DIR}/octavia; git rev-parse HEAD)
+
+# If there are artifacts for this release, then set PUSH_TO_MIRROR to NO
+if amp_image_artifacts_available; then
+  echo "Mirror = NO"
+  export PUSH_TO_MIRROR="NO"
+fi
+
+# If REPLACE_ARTIFACTS is YES then force PUSH_TO_MIRROR to YES
+if [[ "$(echo ${REPLACE_ARTIFACTS} | tr [a-z] [A-Z])" == "YES" ]]; then
+  export PUSH_TO_MIRROR="YES"
+fi
+
+# Only push to the mirror if PUSH_TO_MIRROR is set to "YES"
+#
+# This enables PR-based tests which do not change the artifacts
+#
+if [[ "$(echo ${PUSH_TO_MIRROR} | tr [a-z] [A-Z])" == "YES" ]]; then
+    if [ -z ${REPO_USER_KEY+x} ] || [ -z ${REPO_USER+x} ] || [ -z ${REPO_HOST+x} ] || [ -z ${REPO_HOST_PUBKEY+x} ]; then
+        echo "Skipping upload to rpc-repo as the REPO_* env vars are not set."
+        exit 1
+    else
+
+        # Prep the ssh key for uploading to rpc-repo
+        mkdir -p ~/.ssh/
+        set +x
+        REPO_KEYFILE=~/.ssh/repo.key
+        cat $REPO_USER_KEY > ${REPO_KEYFILE}
+        chmod 600 ${REPO_KEYFILE}
+        set -x
+
+        # Ensure that the repo server public key is a known host
+        grep "${REPO_HOST}" ~/.ssh/known_hosts || echo "${REPO_HOST} $(cat $REPO_HOST_PUBKEY)" >> ~/.ssh/known_hosts
+
+        # Create the Ansible inventory for the upload
+        echo '[mirrors]' > /opt/inventory
+        echo "repo ansible_host=${REPO_HOST} ansible_user=${REPO_USER} ansible_ssh_private_key_file='${REPO_KEYFILE}' " >> /opt/inventory
+
+        # Upload the artifacts to rpc-repo
+        # Todo: set diretcories properly
+        openstack-ansible -i /opt/inventory \
+                          ${MY_BASE_DIR}/gating/scripts/amphora-image-push-to-mirror.yml \
+                          -e rpc_release=${RPC_RELEASE} \
+                          -e git_sha=${GIT_SHA} \
+                          -e working_dir=${MY_BASE_DIR} \
+                          ${ANSIBLE_PARAMETERS}
+    fi
+else
+    echo "Skipping upload to rpc-repo as the PUSH_TO_MIRROR env var is not set to 'YES'."
+fi

--- a/gating/scripts/pre.sh
+++ b/gating/scripts/pre.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Copyright 2014-2017 , Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## Shell Opts ----------------------------------------------------------------
+set -xeuo pipefail
+
+## Vars ----------------------------------------------------------------------
+source /opt/rpc-octavia/gating/scripts/vars.sh
+
+## Main ----------------------------------------------------------------------
+echo "Pre gate job started"
+echo "+-------------------- START ENV VARS --------------------+"
+env
+echo "+-------------------- START ENV VARS --------------------+"
+
+# Deploy RPC-Openstack
+# Assume we have the packages. In my tests I had to add:
+# * sudo add-apt-repository ppa:canonical-kernel-team/ppa
+# * sudo add-apt-repository ppa:ubuntu-toolchain-r/ppa
+if [ ! -d /opt/rpc-openstack ]; then
+  git clone --recursive -b ${RPC_RELEASE} https://github.com/rcbops/rpc-openstack /opt/rpc-openstack
+fi
+cd /opt/rpc-openstack/
+export DEPLOY_AIO="yes"
+bash /opt/rpc-openstack/scripts/deploy.sh
+
+# Install Octavia
+bash /opt/rpc-octavia/scripts/deploy.sh
+
+# install tempest
+cd /opt/rpc-openstack/openstack-ansible/playbooks/
+openstack-ansible  /opt/rpc-openstack/openstack-ansible/playbooks/os-tempest-install.yml
+
+# Build an amphora image to be uplaoded
+# work-around for bug https://github.com/ansible/ansible/issues/14468 deployed
+openstack-ansible ${MY_BASE_DIR}/gating/scripts/rpc-build-image.yml \
+                  -e rpc_release=${RPC_RELEASE} \
+                  -e octavia_tmp_dir=${OCTAVIA_TEMP_DIR} \
+                  -e working_dir=${MY_BASE_DIR} \
+                  -e ansible_python_interpreter=/usr/bin/python \
+                  ${ANSIBLE_PARAMETERS}
+
+echo "Pre gate job ended"

--- a/gating/scripts/rpc-build-image.yml
+++ b/gating/scripts/rpc-build-image.yml
@@ -17,11 +17,10 @@
   hosts: localhost
   user: root
   tasks:
-    - debug: "Experimental - YMMV"
     - name: Gather variables
       include_vars: "{{ item }}"
       with_items:
-        - '/opt/rpc-openstack/openstack-ansible/playbooks/defaults/repo_packages/openstack_services.yml'
+        - '../../../playbooks/vars/cert_vars.yml'
     - name: Install apt packages
       apt:
         pkg: "{{ item }}"
@@ -40,15 +39,12 @@
     - name: Create Octavia tmp dir
       file:
         state: directory
-        path: "/var/lib/octavia"
-    - name: Set Octavia tmp dir
-      set_fact:
-        bootstrap_host_octavia_tmp: "/var/lib/octavia"
+        path: "{{ bootstrap_host_octavia_tmp }}"
     - name: Install pip requirements
       pip:
         name: "{{ item }}"
         state: "present"
-        extra_args: "-c https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?id={{ requirements_git_install_branch | regex_replace(' #.*$','') }}"
+        extra_args: "-c https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?id={{ requirements_git_install_branch | regex_replace(' #.*$','') }} --isolated"
       register: install_packages
       until: install_packages|success
       retries: 5
@@ -63,12 +59,23 @@
       git:
         repo: "https://git.openstack.org/openstack/octavia"
         dest: "{{ bootstrap_host_octavia_tmp }}/octavia"
-        version: "{{ octavia_git_install_branch }}"
+        version: "{{ octavia_git_install_commit }}"
     # Build Octavia amphora image
+    - name: Create amphora directory
+      file:
+        path: "{{ amp_image_file_dir }}"
+        state: directory
+    - name: Create dib directory
+      file:
+        path: "{{ bootstrap_host_octavia_tmp }}/diskimage-builder"
+        state: directory
     - name: Create amphora image
-      shell: "./diskimage-create.sh -o {{ bootstrap_host_octavia_tmp }}/amphora-x64-haproxy.qcow2"
+      shell: "./diskimage-create.sh -o {{ amp_image_file_dir }}/amphora-x64-haproxy.qcow2"
       args:
         chdir: "{{ bootstrap_host_octavia_tmp }}/octavia/diskimage-create"
-        creates: "{{ bootstrap_host_octavia_tmp }}/amphora-x64-haproxy.qcow2"
+        creates: "{{ amp_image_file_dir }}/amphora-x64-haproxy.qcow2"
       tags:
       - skip_ansible_lint
+  vars:
+    bootstrap_host_octavia_tmp: "{{ octavia_tmp_dir }}"
+    amp_image_file_dir: "{{ working_dir }}/amp-image/{{ rpc_release }}"

--- a/gating/scripts/run.sh
+++ b/gating/scripts/run.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Copyright 2014-2017 , Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## Shell Opts ----------------------------------------------------------------
+set -xeuo pipefail
+
+## Vars ----------------------------------------------------------------------
+source /opt/rpc-octavia/gating/scripts/vars.sh
+
+## Main ----------------------------------------------------------------------
+echo "Gate job started"
+echo "+-------------------- START ENV VARS --------------------+"
+env
+echo "+-------------------- START ENV VARS --------------------+"
+
+# Run tests
+echo "RUN OCTAVIA TESTS"
+openstack-ansible ${MY_BASE_DIR}/gating/scripts/test_octavia.yml \
+                  -e octavia_system_home_folder=${OCTAVIA_TEMP_DIR}\
+                  -e working_dir=${MY_BASE_DIR} \
+                  -e rpc_release=${RPC_RELEASE} \
+                  ${ANSIBLE_PARAMETERS}
+
+echo "Gate job ended"

--- a/gating/scripts/test_octavia.yml
+++ b/gating/scripts/test_octavia.yml
@@ -1,0 +1,120 @@
+---
+# Copyright 2014-2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Test Octavia
+  hosts: localhost
+  user: root
+  gather_facts: false
+  vars:
+    env:
+      OS_ENDPOINT_TYPE: internalURL
+      OS_INTERFACE: internalURL
+      OS_USERNAME: admin
+      OS_PASSWORD: "{{ keystone_auth_admin_password }}"
+      OS_PROJECT_NAME: admin
+      OS_TENANT_NAME: admin
+      OS_AUTH_URL: "http://{{ internal_lb_vip_address }}:5000/v3"
+      OS_NO_CACHE: 1
+      OS_USER_DOMAIN_NAME: Default
+      OS_PROJECT_DOMAIN_NAME: Default
+      OS_REGION_NAME: RegionOne
+    requirements_git_install_branch: 99d99fe2e22f4a464415eb0064313b6ebd36906f #HEAD of "stable/pike" as of 4.10.2017
+    internal_lb_vip_address: 172.29.236.100
+    amp_image_file_dir: "{{ working_dir }}/amp-image/{{ rpc_release }}"
+
+  tasks:
+    - name: Gather variables
+      include_vars: "{{ item }}"
+      with_items:
+        - '/etc/ansible/roles/os_octavia/defaults/main.yml'
+        - '/opt/rpc-octavia/playbooks/vars/cert_vars.yml'
+        - '/opt/rpc-octavia/playbooks/group_vars/octavia_all.yml'
+        - '/opt/rpc-octavia/playbooks/group_vars/all/octavia.yml'
+    - name: Install pip requirements
+      pip:
+        name: "{{ item }}"
+        state: "{{ octavia_pip_package_state }}"
+        extra_args: "-c https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?id={{ requirements_git_install_branch | regex_replace(' #.*$','') }} --isolated"
+      register: install_packages
+      until: install_packages|success
+      retries: 5
+      delay: 2
+      with_items:
+        - "python-neutronclient"
+        - "python-glanceclient"
+        - "shade"
+    - name: Upload image to glance
+      shell: >-
+          glance image-create --name amphora-x64-haproxy --visibility private --disk-format qcow2 \
+            --container-format bare --tags octavia-amphora-image <{{ amp_image_file_dir }}/amphora-x64-haproxy.qcow2 \
+            && touch {{ octavia_system_home_folder }}/image
+      args:
+        creates: "{{ octavia_system_home_folder }}/image"
+      environment: "{{ env }}"
+    - name: Create ssh-key
+      shell: >
+          cat /dev/zero | ssh-keygen -q -N ""
+      args:
+        creates: /root/.ssh/id_rsa.pub
+    - name: Upload key to nova
+      os_keypair:
+        auth:
+          auth_url: "http://{{ internal_lb_vip_address }}:5000/v3"
+          username: "{{ octavia_service_user_name }}"
+          password: "{{ octavia_service_password }}"
+          project_name: "{{ octavia_service_project_name }}"
+          user_domain_name: "{{ octavia_service_user_domain_id }}"
+          project_domain_name: "{{ octavia_service_project_domain_id }}"
+        endpoint_type: "{{ octavia_ansible_endpoint_type }}"
+        state: present
+        name: "octavia_key"
+        public_key_file: "/root/.ssh/id_rsa.pub"
+      run_once: true
+
+    - name: Create a loadbalancer
+      shell: >
+         neutron lbaas-loadbalancer-create --name test-lb public-subnet
+      environment: "{{ env }}"
+    - name: Wait until LB is up
+      shell: >
+        neutron lbaas-loadbalancer-show test-lb | grep ONLINE
+      environment: "{{ env }}"
+      register: lb_up
+      until: lb_up|success
+      retries: 50
+      delay: 10
+    - name: Create a listener
+      shell: >
+        neutron lbaas-listener-create  --loadbalancer test-lb --protocol HTTP --protocol-port 80 --name listener
+      environment: "{{ env }}"
+    - name: Curl the Listener
+      shell: >
+        curl -s -o /dev/null -w "%{http_code}" http://`neutron lbaas-loadbalancer-show test-lb | awk '/ vip_address / {print $4}'`
+      environment: "{{ env }}"
+      register: http_status_code
+    - name: Check that we got 503
+      assert:
+        that:
+          - "'503' in http_status_code.stdout"
+    - name: Delete listener
+      shell: >
+        neutron lbaas-listener-delete listener
+      environment: "{{ env }}"
+    - name: Delete LoadBalancer
+      shell: >
+        neutron lbaas-loadbalancer-delete test-lb
+      environment: "{{ env }}"
+      retries: 10
+      delay: 10

--- a/gating/scripts/vars.sh
+++ b/gating/scripts/vars.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Copyright 2014-2017 , Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Set this to YES if you want to replace any existing artifacts for the current
+# release with those built in this job.
+export REPLACE_ARTIFACTS=${REPLACE_ARTIFACTS:-no}
+
+# Set this to YES if you want to push any changes made in this job to rpc-repo.
+export PUSH_TO_MIRROR=${PUSH_TO_MIRROR:-no}
+
+# The MY_BASE_DIR needs to be set to ensure that the scripts
+# know it and use this checkout appropriately.
+export MY_BASE_DIR=${PWD}
+
+# We want the role downloads to be done via git
+export ANSIBLE_ROLE_FETCH_MODE="git-clone"
+
+# Octavia tmp dir
+export OCTAVIA_TEMP_DIR=/var/tmp/
+
+# To provide flexibility in the jobs, we have the ability to set any
+# parameters that will be supplied on the ansible-playbook CLI.
+export ANSIBLE_PARAMETERS=${ANSIBLE_PARAMETERS:--v}
+
+# Pin RPC-Release to 14.3
+export RPC_RELEASE="r14.3.0"

--- a/playbooks/rpc-octavia-setup.yml
+++ b/playbooks/rpc-octavia-setup.yml
@@ -37,7 +37,7 @@
     dest: /etc/openstack_deploy/user_osa_variables_overrides.yml
     block: |
       octavia_git_repo: https://git.openstack.org/openstack/octavia
-      octavia_git_install_branch: 02926d8907335a4108998034bafb757418f4b5ac # HEAD of "stable/pike" as of 15.08.2017
+      octavia_git_install_branch: "{{ octavia_git_install_commit }}"
       octavia_git_project_group: octavia_all
 
       lxc_container_variant: "octavia-{{ rpc_release }}"
@@ -86,3 +86,5 @@
       octavia_loadbalancer_topology: ACTIVE_STANDBY
       octavia_spare_amphora_pool_size: 0
       octavia_enable_anti_affinity: {{ lookup('env', 'DEPLOY_AIO') != "yes" }}
+      # make TRUE to gain SSH access to the amphora
+      octavia_ssh_enabled: {{ lookup('env', 'DEPLOY_AIO') != "yes" }}

--- a/playbooks/vars/cert_vars.yml
+++ b/playbooks/vars/cert_vars.yml
@@ -29,4 +29,6 @@ octavia_ca_certificate: "{{ cert_dir }}/ca_server_01.pem"
 octavia_client_ca: "{{ cert_dir }}/ca_01.pem"
 octavia_client_cert: "{{ cert_dir }}/client.pem"
 
-neutron_octavia_request_poll_timeout: 100
+neutron_octavia_request_poll_timeout: "{{ '1000' if lookup('env', 'DEPLOY_AIO') == 'yes' else '100' }}"
+octavia_git_install_commit: 8565bcd14654165f832f5f5b190551ace160a69d #Head of Octavia stable/pike as of 10.10.2017
+requirements_git_install_branch: 99d99fe2e22f4a464415eb0064313b6ebd36906f #HEAD of "stable/pike" as of 4.10.2017


### PR DESCRIPTION
This will build an amphora imnage and upload it to the artifact
server in a directory with the RPC version and the git-sha of
the octavia repo, e.g.
images/amphora/r14.4.0/02926d8907335a4108998034bafb757418f4b5ac/

It also includes test with the new image which are used for both
post-merge and as a merge-gate.

It is implements as post-gate hook which will run periodically,
build a new image, and test it against an Octavia AIO.