### PR TITLE
Create symlink to rpc-octavia

### DIFF
--- a/gating/scripts/post.sh
+++ b/gating/scripts/post.sh
@@ -17,7 +17,7 @@
 set -xeuo pipefail
 
 ## Vars ----------------------------------------------------------------------
-source /opt/rpc-octavia/gating/scripts/vars.sh
+source ${PWD}/gating/scripts/vars.sh
 
 ## Main ----------------------------------------------------------------------
 function amp_image_artifacts_available {

--- a/gating/scripts/pre.sh
+++ b/gating/scripts/pre.sh
@@ -17,7 +17,7 @@
 set -xeuo pipefail
 
 ## Vars ----------------------------------------------------------------------
-source /opt/rpc-octavia/gating/scripts/vars.sh
+source ${PWD}/gating/scripts/vars.sh
 
 ## Main ----------------------------------------------------------------------
 echo "Pre gate job started"

--- a/gating/scripts/run.sh
+++ b/gating/scripts/run.sh
@@ -17,7 +17,7 @@
 set -xeuo pipefail
 
 ## Vars ----------------------------------------------------------------------
-source /opt/rpc-octavia/gating/scripts/vars.sh
+source ${PWD}/gating/scripts/vars.sh
 
 ## Main ----------------------------------------------------------------------
 echo "Gate job started"

--- a/gating/scripts/test_octavia.yml
+++ b/gating/scripts/test_octavia.yml
@@ -63,26 +63,6 @@
       args:
         creates: "{{ octavia_system_home_folder }}/image"
       environment: "{{ env }}"
-    - name: Create ssh-key
-      shell: >
-          cat /dev/zero | ssh-keygen -q -N ""
-      args:
-        creates: /root/.ssh/id_rsa.pub
-    - name: Upload key to nova
-      os_keypair:
-        auth:
-          auth_url: "http://{{ internal_lb_vip_address }}:5000/v3"
-          username: "{{ octavia_service_user_name }}"
-          password: "{{ octavia_service_password }}"
-          project_name: "{{ octavia_service_project_name }}"
-          user_domain_name: "{{ octavia_service_user_domain_id }}"
-          project_domain_name: "{{ octavia_service_project_domain_id }}"
-        endpoint_type: "{{ octavia_ansible_endpoint_type }}"
-        state: present
-        name: "octavia_key"
-        public_key_file: "/root/.ssh/id_rsa.pub"
-      run_once: true
-
     - name: Create a loadbalancer
       shell: >
          neutron lbaas-loadbalancer-create --name test-lb public-subnet
@@ -116,5 +96,7 @@
       shell: >
         neutron lbaas-loadbalancer-delete test-lb
       environment: "{{ env }}"
+      register: lb_deleted
+      until: lb_deleted|success
       retries: 10
-      delay: 10
+      delay: 15

--- a/gating/scripts/vars.sh
+++ b/gating/scripts/vars.sh
@@ -13,6 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# The scripts expects the git clone to be at /opt/rpc-octavia, so we link
+# the current folder there.
+if [[ "${PWD}" != "/opt/rpc-octavia" ]]; then
+  ln -sfn ${PWD} /opt/rpc-octavia
+fi
+
 # Set this to YES if you want to replace any existing artifacts for the current
 # release with those built in this job.
 export REPLACE_ARTIFACTS=${REPLACE_ARTIFACTS:-no}
@@ -22,7 +28,7 @@ export PUSH_TO_MIRROR=${PUSH_TO_MIRROR:-no}
 
 # The MY_BASE_DIR needs to be set to ensure that the scripts
 # know it and use this checkout appropriately.
-export MY_BASE_DIR=${PWD}
+export MY_BASE_DIR=/opt/rpc-octavia/
 
 # We want the role downloads to be done via git
 export ANSIBLE_ROLE_FETCH_MODE="git-clone"


### PR DESCRIPTION
The CI will check out rpc-octavia to an arbitray directory. This
will create a symlink to /opt/rpc-octavia which the system assumes
we are checked out to.