### PR TITLE
During deploying to rpc-1 we learned

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,4 +73,8 @@ As part of the gate tests (pre and run) the system will automatically create an 
 3. Run tests
     ./gating/[pre_merge_test|post_merge_test]/[pre|run|post]
 
+4. Once you ran pre and it failed you might need to run:
+
+    apt-get install libicu55=55.1-7ubuntu0.2  libssl1.0.0=1.0.2g-1ubuntu4.8
+
 

--- a/gating/scripts/pre.sh
+++ b/gating/scripts/pre.sh
@@ -34,6 +34,7 @@ if [ ! -d /opt/rpc-openstack ]; then
 fi
 cd /opt/rpc-openstack/
 export DEPLOY_AIO="yes"
+export DEPLOY_NEUTRON_LBAAS="yes" # Deploy Neutron-LBaaS for now for our tests
 bash /opt/rpc-openstack/scripts/deploy.sh
 
 # Install Octavia

--- a/gating/scripts/test_octavia.yml
+++ b/gating/scripts/test_octavia.yml
@@ -30,6 +30,8 @@
       OS_USER_DOMAIN_NAME: Default
       OS_PROJECT_DOMAIN_NAME: Default
       OS_REGION_NAME: RegionOne
+      OS_IDENTITY_API_VERSION: 3
+      OS_AUTH_VERSION: 3
     requirements_git_install_branch: 99d99fe2e22f4a464415eb0064313b6ebd36906f #HEAD of "stable/pike" as of 4.10.2017
     internal_lb_vip_address: 172.29.236.100
     amp_image_file_dir: "{{ working_dir }}/amp-image/{{ rpc_release }}"
@@ -55,6 +57,8 @@
         - "python-neutronclient"
         - "python-glanceclient"
         - "shade"
+        - "python-octaviaclient"
+        - "python-openstackclient"
     - name: Upload image to glance
       shell: >-
           glance image-create --name amphora-x64-haproxy --visibility private --disk-format qcow2 \
@@ -65,36 +69,47 @@
       environment: "{{ env }}"
     - name: Create a loadbalancer
       shell: >
-         neutron lbaas-loadbalancer-create --name test-lb public-subnet
+         openstack --debug loadbalancer create  --name test-lb --vip-subnet-id public-subnet
       environment: "{{ env }}"
-    - name: Wait until LB is up
+    - name: Wait until LB is active
       shell: >
-        neutron lbaas-loadbalancer-show test-lb | grep ONLINE
+         openstack loadbalancer show test-lb -c provisioning_status -f value
       environment: "{{ env }}"
-      register: lb_up
-      until: lb_up|success
+      register: lb_active
+      until: lb_active.stdout == "ACTIVE"
       retries: 50
       delay: 10
     - name: Create a listener
       shell: >
-        neutron lbaas-listener-create  --loadbalancer test-lb --protocol HTTP --protocol-port 80 --name listener
+       openstack loadbalancer listener create --protocol HTTP --protocol-port 80 --name listener test-lb
       environment: "{{ env }}"
-    - name: Curl the Listener
+    - name: Wait until Listener is active
       shell: >
-        curl -s -o /dev/null -w "%{http_code}" http://`neutron lbaas-loadbalancer-show test-lb | awk '/ vip_address / {print $4}'`
+         openstack loadbalancer show test-lb -c provisioning_status -f value
       environment: "{{ env }}"
-      register: http_status_code
-    - name: Check that we got 503
-      assert:
-        that:
-          - "'503' in http_status_code.stdout"
-    - name: Delete listener
+      register: lb_active
+      until: lb_active.stdout == "ACTIVE"
+      retries: 10
+      delay: 10
+    - name: Run Show
       shell: >
-        neutron lbaas-listener-delete listener
+        openstack loadbalancer show test-lb
       environment: "{{ env }}"
+    - name: Register VIP IP # this is likley changing with a newer version of octaviaclient
+      shell: >
+         openstack loadbalancer show test-lb -c vip_Address -f value
+      environment: "{{ env }}"
+      register: vip_output
+    - name: Set VIP fact
+      set_fact:
+        vip: "{{ vip_output.stdout }}"
+    - name: Test the Listener
+      uri:
+        url: "http://{{ vip }}"
+        status_code: 503
     - name: Delete LoadBalancer
       shell: >
-        neutron lbaas-loadbalancer-delete test-lb
+        openstack loadbalancer delete --cascade test-lb
       environment: "{{ env }}"
       register: lb_deleted
       until: lb_deleted|success

--- a/gating/scripts/vars.sh
+++ b/gating/scripts/vars.sh
@@ -41,4 +41,4 @@ export OCTAVIA_TEMP_DIR=/var/tmp/
 export ANSIBLE_PARAMETERS=${ANSIBLE_PARAMETERS:--v}
 
 # Pin RPC-Release to 14.3
-export RPC_RELEASE="r14.3.0"
+export RPC_RELEASE="r14.4.1"

--- a/playbooks/group_vars/all/octavia.yml
+++ b/playbooks/group_vars/all/octavia.yml
@@ -33,7 +33,7 @@ octavia_rabbitmq_host_group: "{{ rabbitmq_host_group }}"
 # Overwrite haproxy
 haproxy_octavia_whitelist_networks: "{{ haproxy_whitelist_networks }}"
 
-haproxy_extra_services:
+haproxy_service_configs:
   - service:
       haproxy_service_name: octavia
       haproxy_backend_nodes: "{{ groups['octavia_all'] | default([]) }}"

--- a/playbooks/rpc-octavia-setup.yml
+++ b/playbooks/rpc-octavia-setup.yml
@@ -50,10 +50,12 @@
 
 
       # activate octavia
-      octavia_v2: False
-      octavia_v1: True
-      octavia_auth_strategy: noauth # Run V1 with noauth
+      octavia_v2: True
+      octavia_v1: "{{ lookup('env', 'DEPLOY_NEUTRON_LBAAS') == 'yes' }}"
       octavia_tls_listener_enabled: False # we don't have Barbican
+
+      {% if lookup('env', 'DEPLOY_NEUTRON_LBAAS') == "yes" %}
+      # delete this if you don't use neutron-lbaas
       neutron_lbaas_octavia: True
       neutron_lbaasv2: True
       neutron_lbaasv2_service_provider: |
@@ -73,17 +75,18 @@
         auth_url = {{ keystone_service_internaluri }}/v3
         admin_project_domain = default
         admin_user_domain = default
-        admin_tenant_name = service
+        admin_tenant_name = admin
         admin_user = {{ neutron_service_user_name }}
         admin_password = {{ neutron_service_password }}
         region = {{ keystone_service_region }}
         endpoint_type = internalURL
         service_name = neutron
         auth_version = 3
+      {% endif %}
 
       # Octavia HA settings
       octavia_loadbalancer_topology: ACTIVE_STANDBY
       octavia_spare_amphora_pool_size: 0
       octavia_enable_anti_affinity: {{ lookup('env', 'DEPLOY_AIO') != "yes" }}
       # make TRUE to gain SSH access to the amphora
-      octavia_ssh_enabled: {{ lookup('env', 'DEPLOY_AIO') != "yes" }}
+      octavia_ssh_enabled: False # Chnage to true if ssh debugging is needed


### PR DESCRIPTION
- switch ssh acces off since we don't have the required ssh key
- switch lbaas_v2 on so we can access Octavia API directly
- make neutron config optional
- chnage haproxy var