### PR TITLE
Gate fixes

### DIFF
--- a/gating/scripts/post.sh
+++ b/gating/scripts/post.sh
@@ -18,6 +18,7 @@ set -xeuo pipefail
 
 ## Vars ----------------------------------------------------------------------
 source ${PWD}/gating/scripts/vars.sh
+source /opt/rpc-openstack/scripts/functions.sh
 
 ## Main ----------------------------------------------------------------------
 function amp_image_artifacts_available {

--- a/playbooks/rpc-octavia-setup.yml
+++ b/playbooks/rpc-octavia-setup.yml
@@ -52,6 +52,7 @@
       # activate octavia
       octavia_v2: False
       octavia_v1: True
+      octavia_auth_strategy: noauth # Run V1 with noauth
       octavia_tls_listener_enabled: False # we don't have Barbican
       neutron_lbaas_octavia: True
       neutron_lbaasv2: True


### PR DESCRIPTION
- Sources rpc-opensatck's functions.sh
- Switches off auth for V1 API so neutron commands will succeed