### PR TITLE
RE-35 Update test to reflect RE_JOB_TRIGGER change

### DIFF
--- a/gating/scripts/vars.sh
+++ b/gating/scripts/vars.sh
@@ -24,7 +24,7 @@ fi
 export REPLACE_ARTIFACTS=${REPLACE_ARTIFACTS:-no}
 
 # Are we a post merge job?
-if [[ "$(echo ${RE_JOB_TRIGGER:0:2}| tr [a-z] [A-Z])" == "PM" ]]; then
+if [[ "$(echo ${RE_JOB_TRIGGER}| tr [a-z] [A-Z])" == "TIMER" ]]; then
   export PM_JOB="yes"
 else
   export PM_JOB="no"


### PR DESCRIPTION
RE-35 adds some more granularity to RE_JOB_TRIGGER. This commit updates
var.sh to use one of the new values.

Do not merge before https://github.com/rcbops/rpc-gating/pull/549 has merged.