### PR TITLE
Don't instal legacy role policies

### DIFF
--- a/playbooks/rpc-octavia-setup.yml
+++ b/playbooks/rpc-octavia-setup.yml
@@ -53,6 +53,7 @@
       octavia_v2: True
       octavia_v1: "{{ lookup('env', 'DEPLOY_NEUTRON_LBAAS') == 'yes' }}"
       octavia_tls_listener_enabled: False # we don't have Barbican
+      octavia_legacy_policy: False # We will always add the role to the K8 servcie user
 
       {% if lookup('env', 'DEPLOY_NEUTRON_LBAAS') == "yes" %}
       # delete this if you don't use neutron-lbaas


### PR DESCRIPTION
K8 will always add the role to the K8 servcie user ddirectly.