### PR TITLE
Fix quotas

### DIFF
--- a/gating/scripts/rpc-build-image.yml
+++ b/gating/scripts/rpc-build-image.yml
@@ -20,7 +20,7 @@
     - name: Gather variables
       include_vars: "{{ item }}"
       with_items:
-        - '../../../playbooks/vars/cert_vars.yml'
+        - '../../../playbooks/vars/main.yml'
     - name: Install apt packages
       apt:
         pkg: "{{ item }}"

--- a/gating/scripts/test_octavia.yml
+++ b/gating/scripts/test_octavia.yml
@@ -41,7 +41,7 @@
       include_vars: "{{ item }}"
       with_items:
         - '/etc/ansible/roles/os_octavia/defaults/main.yml'
-        - '/opt/rpc-octavia/playbooks/vars/cert_vars.yml'
+        - '/opt/rpc-octavia/playbooks/vars/main.yml'
         - '/opt/rpc-octavia/playbooks/group_vars/octavia_all.yml'
         - '/opt/rpc-octavia/playbooks/group_vars/all/octavia.yml'
     - name: Install pip requirements

--- a/playbooks/main.yml
+++ b/playbooks/main.yml
@@ -20,7 +20,7 @@
     - name: Gather variables
       include_vars: "{{ item }}"
       with_items:
-        - 'vars/cert_vars.yml'
+        - 'vars/main.yml'
         - 'group_vars/octavia_all.yml'
         - 'group_vars/all/octavia.yml'
       tags:
@@ -42,3 +42,25 @@
     - include: rpc-octavia-setup.yml
       tags:
         - octavia-setup
+
+    - name: Fix quotas
+      shell: |
+        . {{ ansible_env.HOME }}/openrc
+        openstack quota set \
+          --cores "{{ octavia_num_cores }}" \
+          --instances "{{ octavia_num_instances }}" \
+          --ram "{{ octavia_ram }}" \
+          --server-groups "{{ octavia_num_server_groups }}" \
+          --server-group-members "{{ octavia_num_server_group_members }} " \
+          --gigabytes "{{ octavia_volume_gigabytes }}" \
+          --volumes "{{ octavia_num_volumes }}" \
+          --secgroups "{{ octavia_num_secgroups }}" \
+          --ports "{{ octavia_num_ports }}" \
+          --secgroup-rules "{{ octavia_num_secgroups }}" \
+          service
+      delegate_to: "{{ groups['utility_all'][0] }}"
+      tags:
+        - octavia-quota-setup
+        - octavia-setup
+        - skip_ansible_lint
+

--- a/playbooks/vars/main.yml
+++ b/playbooks/vars/main.yml
@@ -32,3 +32,16 @@ octavia_client_cert: "{{ cert_dir }}/client.pem"
 neutron_octavia_request_poll_timeout: "{{ '1000' if lookup('env', 'DEPLOY_AIO') == 'yes' else '100' }}"
 octavia_git_install_commit: d9e24e83bbf7d12f8bec16072b28c6ca655690ac #Head of Octavia stable/pike as of 4.1.2018
 requirements_git_install_branch: 99d99fe2e22f4a464415eb0064313b6ebd36906f #HEAD of "stable/pike" as of 4.10.2017
+
+octavia_num_cores: 1000
+octavia_num_instances: 10000
+octavia_ram: "{{ octavia_num_instances*1024 }}"
+octavia_num_server_groups: "{{ (octavia_num_instances*0.5)|int|abs }}"
+octavia_num_server_group_members: 50
+octavia_volume_gigabytes:  "{{ octavia_num_instances*2 }}"
+octavia_num_volumes: "{{ octavia_num_instances }}"
+octavia_num_secgroups: "{{ octavia_num_instances }}"
+octavia_num_ports: "{{ octavia_num_instances*10 }}" # at least instances * 10
+octavia_num_security_group_rules: 100
+
+


### PR DESCRIPTION
The service project in rpc-o is running with the default quotas which
are not sufficient for Octavia to create LB in a production setting.
This adds some reasonable defaults which should let a customer create
about ~1000 LB (cloud permitting)

In a followup patch in MaaS we will set up monitoring for those values