### PR TITLE
Incorporates the branch name into the amp image artefact name

### DIFF
--- a/gating/scripts/amphora-image-push-to-mirror.yml
+++ b/gating/scripts/amphora-image-push-to-mirror.yml
@@ -18,7 +18,7 @@
 - name: Push the git artifacts to rpc-repo
   hosts: mirrors
   vars:
-    src_amp_archive_dir: "{{ working_dir }}/amp-image/{{ rpc_release }}"
+    src_amp_archive_dir: "{{ working_dir }}/amp-image/{{ rpc_release }}-{{ rpc_gating_branch }}"
     dst_amp_archive_dir: "/var/www/repo/images/amphora"
   tasks:
 

--- a/gating/scripts/post.sh
+++ b/gating/scripts/post.sh
@@ -23,8 +23,8 @@ source /opt/rpc-openstack/scripts/functions.sh
 ## Main ----------------------------------------------------------------------
 function amp_image_artifacts_available {
 
-    CHECK_URL="${HOST_RCBOPS_REPO}/images/amphora/${RPC_RELEASE}/amphora-x64-haproxy.qcow2"
-    LOCAL_FILE="${MY_BASE_DIR}/amp-image/${RPC_RELEASE}/amphora-x64-haproxy.qcow2"
+    CHECK_URL="${HOST_RCBOPS_REPO}/images/amphora/${RPC_RELEASE}-${RPC_GATING_BRANCH}/amphora-x64-haproxy.qcow2"
+    LOCAL_FILE="${MY_BASE_DIR}/amp-image/${RPC_RELEASE}-${RPC_GATING_BRANCH}/amphora-x64-haproxy.qcow2"
 
     # Does the file exist?
     if curl --output /dev/null --silent --head --fail ${CHECK_URL}; then
@@ -90,6 +90,7 @@ if [[ "$(echo ${PUSH_TO_MIRROR} | tr [a-z] [A-Z])" == "YES" ]]; then
                           ${MY_BASE_DIR}/gating/scripts/amphora-image-push-to-mirror.yml \
                           -e rpc_release=${RPC_RELEASE} \
                           -e working_dir=${MY_BASE_DIR} \
+                          -e rpc_gating_branch=${RPC_GATING_BRANCH} \
                           ${ANSIBLE_PARAMETERS}
     fi
 else

--- a/gating/scripts/pre.sh
+++ b/gating/scripts/pre.sh
@@ -51,6 +51,7 @@ openstack-ansible  /opt/openstack-ansible/playbooks/os-tempest-install.yml
 # work-around for bug https://github.com/ansible/ansible/issues/14468 deployed
 openstack-ansible ${MY_BASE_DIR}/gating/scripts/rpc-build-image.yml \
                   -e rpc_release=${RPC_RELEASE} \
+                  -e rpc_gating_branch=${RPC_GATING_BRANCH} \
                   -e octavia_tmp_dir=${OCTAVIA_TEMP_DIR} \
                   -e working_dir=${MY_BASE_DIR} \
                   -e ansible_python_interpreter=/usr/bin/python \

--- a/gating/scripts/rpc-build-image.yml
+++ b/gating/scripts/rpc-build-image.yml
@@ -78,4 +78,4 @@
       - skip_ansible_lint
   vars:
     bootstrap_host_octavia_tmp: "{{ octavia_tmp_dir }}"
-    amp_image_file_dir: "{{ working_dir }}/amp-image/{{ rpc_release }}"
+    amp_image_file_dir: "{{ working_dir }}/amp-image/{{ rpc_release }}-{{ rpc_gating_branch }}"

--- a/gating/scripts/run.sh
+++ b/gating/scripts/run.sh
@@ -31,6 +31,7 @@ openstack-ansible ${MY_BASE_DIR}/gating/scripts/test_octavia.yml \
                   -e octavia_system_home_folder=${OCTAVIA_TEMP_DIR}\
                   -e working_dir=${MY_BASE_DIR} \
                   -e rpc_release=${RPC_RELEASE} \
+                  -e rpc_gating_branch=${RPC_GATING_BRANCH} \
                   ${ANSIBLE_PARAMETERS}
 
 echo "Gate job ended"

--- a/gating/scripts/test_octavia.yml
+++ b/gating/scripts/test_octavia.yml
@@ -34,7 +34,7 @@
       OS_AUTH_VERSION: 3
     requirements_git_install_branch: 99d99fe2e22f4a464415eb0064313b6ebd36906f #HEAD of "stable/pike" as of 4.10.2017
     internal_lb_vip_address: 172.29.236.100
-    amp_image_file_dir: "{{ working_dir }}/amp-image/{{ rpc_release }}"
+    amp_image_file_dir: "{{ working_dir }}/amp-image/{{ rpc_release }}-{{ rpc_gating_branch }}"
 
   tasks:
     - name: Gather variables

--- a/playbooks/vars/main.yml
+++ b/playbooks/vars/main.yml
@@ -23,7 +23,7 @@ cert_client_ca_subject: '/C=US/ST=Denial/L=Nowhere/O=Dis/CN=www.example.com' # c
 cert_client_req_subject: '/C=US/ST=Denial/L=Nowhere/O=Dis/CN=www.example.com' # change this to something more real
 generate_client_cert: True # generate self signed client certs
 download_artefact: True
-octavia_artefact_url: http://rpc-repo.rackspace.com//images/amphora/r14.3.0/amphora-x64-haproxy.qcow2
+octavia_artefact_url: http://rpc-repo.rackspace.com//images/amphora/r16.0.1/amphora-x64-haproxy.qcow2
 octavia_amp_image_path: /root/amphora-x64-haproxy-r14.3.0.qcow2
 octavia_amp_artefact_version: r14.3.0
 


### PR DESCRIPTION
To allow for teh rpc-o version not being enough of a differntiator
between code bases this will incorporate the brnach name into the
artefact name.