### PR TITLE
Bumps the verison of Octavia and deactivates EventStreamer (#44)

### DIFF
--- a/playbooks/rpc-octavia-setup.yml
+++ b/playbooks/rpc-octavia-setup.yml
@@ -53,10 +53,13 @@
       octavia_v2: True
       octavia_v1: "{{ lookup('env', 'DEPLOY_NEUTRON_LBAAS') == 'yes' }}"
       octavia_tls_listener_enabled: False # we don't have Barbican
-      octavia_legacy_policy: False # We will always add the role to the K8 servcie user
+
+      # no event streamer
+      octavia_event_streamer: False
 
       {% if lookup('env', 'DEPLOY_NEUTRON_LBAAS') == "yes" %}
       # delete this if you don't use neutron-lbaas
+      octavia_event_streamer: True # we need that for n-lbaas + Octavia
       neutron_lbaas_octavia: True
       neutron_lbaasv2: True
       neutron_lbaasv2_service_provider: |

--- a/playbooks/vars/main.yml
+++ b/playbooks/vars/main.yml
@@ -34,7 +34,7 @@ octavia_client_ca: "{{ cert_dir }}/ca_01.pem"
 octavia_client_cert: "{{ cert_dir }}/client.pem"
 
 neutron_octavia_request_poll_timeout: "{{ '1000' if lookup('env', 'DEPLOY_AIO') == 'yes' else '100' }}"
-octavia_git_install_commit: 5c2d2d2e5c665312f380061ddaead6d7d47d9737 #Head of Octavia stable/pike as of 4.4.2018
+octavia_git_install_commit: 9e744683e822a70b1b97e5f82db94603e78fc6e6 #Head of Octavia stable/pike as of 4.24.2018
 requirements_git_install_branch: 188248aab9bb834023a6cbe2f5e488e30e6046a3 #HEAD of "stable/pike" as of 23.3.2018
 
 octavia_num_instances: 10000


### PR DESCRIPTION
This version is using the process based health manager.

It also switches off the even streamer which is used to sync with
n-lbaas which is no longer deployed.