### PR TITLE
RE-1550 Handle snapshot deployment

### DIFF
--- a/gating/scripts/pre.sh
+++ b/gating/scripts/pre.sh
@@ -35,7 +35,9 @@ fi
 cd /opt/rpc-openstack/
 export DEPLOY_AIO="yes"
 export DEPLOY_NEUTRON_LBAAS="yes" # Deploy Neutron-LBaaS for now for our tests
-bash /opt/rpc-openstack/scripts/deploy.sh
+if [[ ! ${RE_JOB_IMAGE} =~ _snapshot$ ]]; then
+  bash /opt/rpc-openstack/scripts/deploy.sh
+fi
 
 # Install Octavia
 bash /opt/rpc-octavia/scripts/deploy.sh

--- a/gating/scripts/test_octavia.yml
+++ b/gating/scripts/test_octavia.yml
@@ -83,7 +83,7 @@
       register: lb_active
       until: lb_active.stdout == "ACTIVE"
       failed_when: lb_active.stdout == "ERROR"
-      retries: 50
+      retries: 100
       delay: 10
     - name: Create a listener
       shell: >
@@ -96,7 +96,7 @@
       register: lb_active
       until: lb_active.stdout == "ACTIVE"
       failed_when: lb_active.stdout == "ERROR"
-      retries: 10
+      retries: 20
       delay: 10
     - name: Run Show
       shell: >

--- a/playbooks/templates/octavia.yml.aio.j2
+++ b/playbooks/templates/octavia.yml.aio.j2
@@ -1,4 +1,4 @@
 # The controller host that the octavia control plane will be run on
 octavia-infra_hosts:
-  {{ ansible_hostname }}:
+  {{ groups['shared-infra_hosts'][0] }}:
     ip: 172.29.236.100


### PR DESCRIPTION
This commit updates gating/scripts/pre.sh to skip the deployment of
rpc-openstack if we're building from a snapshotted image. We also
adjust some timeouts since booting from a snapshot (which requires the
use of legacy public cloud flavours) takes a little longer than
builds that happen on standard images (which build with the performance
flavours).

Lastly, we adjust playbooks/templates/octavia.yml.aio.j2 to use
groups['shared-infra_hosts'][0] instead of ansible_hostname since when
building on a snapshot image the hostname of the build will not match
what's in the inventory.