### PR TITLE
Runs only one amp in an AIO

### DIFF
--- a/playbooks/rpc-octavia-setup.yml
+++ b/playbooks/rpc-octavia-setup.yml
@@ -89,7 +89,7 @@
       {% endif %}
 
       # Octavia HA settings
-      octavia_loadbalancer_topology: ACTIVE_STANDBY
+      octavia_loadbalancer_topology: {{ octavia_loadbalancer_topology }}
       octavia_spare_amphora_pool_size: 0
       octavia_enable_anti_affinity: {{ lookup('env', 'DEPLOY_AIO') != "yes" }}
       # make TRUE to gain SSH access to the amphora

--- a/playbooks/vars/main.yml
+++ b/playbooks/vars/main.yml
@@ -26,12 +26,14 @@ download_artefact: True
 octavia_artefact_url: http://rpc-repo.rackspace.com//images/amphora/r14.3.0/amphora-x64-haproxy.qcow2
 octavia_amp_image_path: /root/amphora-x64-haproxy-r14.3.0.qcow2
 octavia_amp_artefact_version: r14.3.0
+octavia_loadbalancer_topology: "{{ 'SINGLE' if lookup('env', 'DEPLOY_AIO') == 'yes' else 'ACTIVE_STANDBY' }}"
 
 octavia_ca_private_key: "{{ cert_dir }}/private/cakey.pem"
 octavia_ca_private_key_passphrase: "{{ cert_password_client }}"
 octavia_ca_certificate: "{{ cert_dir }}/ca_server_01.pem"
 octavia_client_ca: "{{ cert_dir }}/ca_01.pem"
 octavia_client_cert: "{{ cert_dir }}/client.pem"
+
 
 neutron_octavia_request_poll_timeout: "{{ '1000' if lookup('env', 'DEPLOY_AIO') == 'yes' else '100' }}"
 octavia_git_install_commit: cc81360c5e054663126e1df704cec2b7635cc5d3 #Head of Octavia stable/pike as of 4.6.2018


### PR DESCRIPTION
To reduce memory consumption + CPU run only one
amp (SINGLE) instead of two (ACTIVE_PASSIVE) when
running in an AIO.