### PR TITLE
K8S-1286 Make rpc-octavia to not install network default

### DIFF
--- a/gating/scripts/pre.sh
+++ b/gating/scripts/pre.sh
@@ -34,11 +34,12 @@ if [ ! -d /opt/rpc-openstack ]; then
 fi
 cd /opt/rpc-openstack/
 export DEPLOY_AIO="yes"
-export DEPLOY_NEUTRON_LBAAS="yes" # Deploy Neutron-LBaaS for now for our tests
 if [[ ! ${RE_JOB_IMAGE} =~ _snapshot$ ]]; then
   bash /opt/rpc-openstack/scripts/deploy.sh
 fi
 
+export SETUP_NETWORK=True
+export CONFIGURE_NETWORK=True
 # Install Octavia
 bash /opt/rpc-octavia/scripts/deploy.sh
 

--- a/playbooks/vars/main.yml
+++ b/playbooks/vars/main.yml
@@ -49,8 +49,8 @@ octavia_num_ports: "{{ octavia_num_instances*10 }}" # at least instances * 10
 octavia_num_security_group_rules: 100
 
 # network
-setup_network: True
-configure_network: True
+setup_network: False
+configure_network: False
 vlan_id: 111
 br_lbaas_prefix: 10.0.252 #first three number blocks
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -21,12 +21,12 @@ set -o pipefail
 export BASE_DIR=${BASE_DIR:-"/opt/rpc-openstack"}
 source ${BASE_DIR}/scripts/functions.sh
 
-#install octavoa file into conf.d
+#install octavia file into conf.d
 if [[ "${DEPLOY_AIO}" == "yes" ]]; then
   run_ansible /opt/rpc-octavia/playbooks/rpc-octavia-aio.yml
 fi
 # setup Octavia
-run_ansible /opt/rpc-octavia/playbooks/main.yml -e "download_artefact=${AMP_DOWNLOAD:-True}"
+run_ansible /opt/rpc-octavia/playbooks/main.yml -e "download_artefact=${AMP_DOWNLOAD:-True}" -e "setup_network=${SETUP_NETWORK:-False}" -e "configure_network=${CONFIGURE_NETWORK:=False}"
 
 cd /opt/rpc-openstack/openstack-ansible/playbooks/
 


### PR DESCRIPTION
rpc-octavia has a setting to perform network setup. This chnages this
from True to False aka make it skip the setup by default. Additionally,
we expose the setting as an enviornment variable and set it to
'True' for the tests.