### PR TITLE
Migrating octavia scripts and docs out of the kaas repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,16 @@ below.
 # Installation instructions
 * managed k8s - newton: Docs are in the k8s repos
 * Pike: draft installation.md
+
+# Kaas migration
+
+We are moving the octavia setup scripts and docs from the kaas repo to this EOL repo to save the
+information on older installs if needed. 
+
+This repo(rpc-octavia) was referenced by kubernetes to install octavia pre-queens in the docs.  For queens
+and later, the deploy docs for support will be updated.  I'm keeping the same kaas directory structure under
+kaas-migration to match the currentl kaas repo locations for those who are already familiar. 
+
+* A copy of the kaas rpco quota fix playbook can be found [here](kaas-migration/rpc/rpc-o/playbooks/setup_octavia.yml).
+* A copy of the kaas rpco deployment docs have been placed [here](kaas-migration/docs/internal/deployment/prepare-provider/rkaas-rpco/).
+

--- a/kaas-migration/docs/internal/deployment/prepare-provider/rkaas-rpco/deploy-lbaas.rst
+++ b/kaas-migration/docs/internal/deployment/prepare-provider/rkaas-rpco/deploy-lbaas.rst
@@ -1,0 +1,49 @@
+.. _deploy-lbaas:
+
+=======================================================
+Deploy a Load Balancer as a Service (OpenStack octavia)
+=======================================================
+
+Rackspace Private Cloud Powered by OpenStack (RPCO) supports
+OpenStack octavia, a Load Balancer as a Service program
+that provides enhanced workload distribution across RPCO infrastructure
+nodes, as well as simplifies the scalability and reliability of your cloud.
+Therefore, a load balancer is an essential part of any efficient and high
+performance cloud infrastructure. In the current implementation, octavia
+is required for the Rackspace KaaS solution.
+
+This section describes how to prepare your RPCO environment for
+OpenStack octavia LBaaS installation,
+how to configure and deploy octavia using OpenStack-Ansible (OSA),
+and how to verify the installation.
+
+.. note::
+   These instructions describe how to deploy octavia on
+   OpenStack Newton and specifically focus on the Rackpace
+   KaaS product requirements. For instructions on
+   how to deploy octavia on OpenStack Pike or later, see
+   the `RPCO Installation Guide
+   <https://pages.github.rackspace.com/rpc-internal/docs-rpc/rpc-install-internal/index.html#rpc-install-internal>`_.
+
+For more information, see the
+`OpenStack-Ansible Deployment Guide
+<http://docs.openstack.org/project-deploy-guide/openstack-ansible/newton/>`_.
+
+For more information about OpenStack octavia, see the `Octavia documentation
+<https://docs.openstack.org/octavia/latest/reference/introduction.html>`_.
+
+For the latest information about how the RPCO octavia LBaaS implementation
+might differ from upstream, see the
+`RPCO Release Notes <https://developer.rackspace.com/docs/private-cloud/rpc/v17/rpc-releasenotes>`__.
+
+.. note::
+
+   RPCO provides LBaaS as a technical preview, which should not be
+   used for production workloads. For more information about LBaaS
+   limitations and restrictions, see the RPCO Release Notes.
+
+.. toctree::
+   :maxdepth: 2
+
+   lbaas/octavia-prepare.rst
+   lbaas/octavia-install.rst

--- a/kaas-migration/docs/internal/deployment/prepare-provider/rkaas-rpco/index.rst
+++ b/kaas-migration/docs/internal/deployment/prepare-provider/rkaas-rpco/index.rst
@@ -1,0 +1,14 @@
+.. _rkaas-rpco:
+
+================================================
+Prepare an RPCO environment to deploy Kubernetes
+================================================
+
+This section describes how to prepare a Rackspace Private Cloud Powered by
+OpenStack (RPCO) environment for deploying Kubernetes clusters.
+
+.. toctree::
+   :maxdepth: 2
+
+   prepare-rpco.rst
+   deploy-lbaas.rst

--- a/kaas-migration/docs/internal/deployment/prepare-provider/rkaas-rpco/lbaas/octavia-install.rst
+++ b/kaas-migration/docs/internal/deployment/prepare-provider/rkaas-rpco/lbaas/octavia-install.rst
@@ -1,0 +1,218 @@
+.. _octavia-install:
+
+Install OpenStack octavia
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+After you complete all tasks in :ref:`octavia-prepare`
+and :ref:`octavia-configure-osa`, you can install OpenStack octavia.
+By default, the octavia deployment script places octavia containers
+on the RPCO infrastructure nodes where all playbooks are stored in
+the ``setup-hosts.yml`` file. We do not recommend changing this
+configuration. However, if you have to deploy octavia on separate
+nodes because of resource constraints, you need to configure
+it accordingly.
+
+To install OpenStack octavia follow these steps:
+
+#. Log in to an RPCO infrastructure node.
+#. Clone the ``rpc-octavia`` repository by running:
+
+   .. code-block:: bash
+
+      cd /opt && git clone https://github.com/rcbops/rpc-octavia.git
+
+   *  If you install octavia on any nodes other than the RPCO
+      infrastructure nodes, complete the following steps:
+
+      #. Log in to the node from which you deploy the RPCO environment.
+
+      #. Configure octavia to be deployed on separate nodes:
+
+         .. code-block:: bash
+
+           cd /opt/rpc-openstack/openstack-ansible/playbooks
+           openstack-ansible --limit '*octavia*' setup-hosts.yml
+
+      The command runs the following playbooks:
+
+      - ``openstack-hosts-setup.yml``
+      - ``security-hardening.yml``
+      - ``lxc-hosts-setup.yml``
+      - ``lxc-containers-create.yml``
+
+#. Run the Octavia installation script:
+
+   .. code-block:: bash
+
+      cd /opt/rpc-octavia && ./scripts/deploy.sh
+
+   The script downloads the octavia amphora image. If the script fails, see
+   :ref:`octavia-install-manually`.
+
+.. _octavia-verify-installation:
+
+Verify the octavia installation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Verify the octavia installation by creating a load balancer.
+Follow these steps:
+
+#. Log in to an RPCO infrastructure node.
+#. Attach to the utility container:
+
+   .. code-block:: bash
+
+      lxc-attach -n <utility-container-name>
+
+#. Source your environment file:
+
+   .. code-block:: bash
+
+      source <openrc.sh>
+
+#. If your RPCO environment uses OpenStack Newton,
+   install octavia CLI:
+
+   .. code-block:: bash
+
+      pip install --isolated python-octaviaclient
+
+   .. note:: If you run OpenStack Pike or later, skip this step.
+
+#. Create a load balancer:
+
+   .. code-block:: bash
+
+      openstack loadbalancer create --name test-lb --vip-network-id GATEWAY_NET
+
+#. Run the following command to view the list of load balancers:
+
+   .. code-block:: bash
+
+      openstack loadbalancer list
+
+#. Repeat the command above until the load balancer becomes **ACTIVE**.
+#. Create a listener for HTTP traffic on port 80:
+
+   .. code-block:: bash
+
+      openstack loadbalancer listener create --name test-listener --protocol HTTP --protocol-port 80 test-lb
+
+#. Verify that the listener operates correctly:
+
+   .. code-block:: bash
+
+      curl -s -o /dev/null -w "%{http_code}" http://$(openstack loadbalancer
+      show test-lb -c vip_address -f value)
+
+   This command must return a ``503`` response code.
+
+.. _octavia-verify-network:
+
+Verify the octavia provider network
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+OpenStack octavia uses restrictive security group settings on its virtual
+machines list, as well as restrictive ``iptables`` settings on the container.
+Therefore, at times, diagnosing network issues might be challenging.
+
+To verify the octavia provider network is operational, try the following
+options:
+
+* Ping the octavia bridge (``br-lbaas``) from the octavia container. You
+  should see the standard ping output.
+
+* Ping the VLAN (``br-vlan``) from the octavia container. You should
+  see the standard ping output.
+
+* Ping the octavia container on a different RPCO infrastructure node. You
+  should see ping timeout errors. Verify that ``arp -nif`` returns the MAC
+  address of the container from the other RPCO infrastructure node.
+
+* Verify the Neutron configuration:
+
+  #. Verify the VLAN ID, network type, and other parameters by running:
+
+     .. code-block:: bash
+
+        openstack network show lbaas-mgmt
+
+  #. Verify that the IP allocation pool does not overlap with the existing IP
+     addresses:
+
+     .. code-block:: bash
+
+        openstack subnet show lbaas-mgmt-subnet
+
+  #. Verify connectivity between the Neutron components on different
+     infrastructure nodes:
+
+     #. Attach to the ``neutron-agents`` container on one of the
+        infrastructure node:
+
+     .. code-block:: bash
+
+        lxc-attach -n <neutron-agents-container>
+
+     #. Display network namespaces:
+
+        .. code-block:: bash
+
+           ip netns list
+
+        Remember the first DHCP server namespace name.
+
+     #. View the list of IP addresses for the namespace:
+
+       .. code-block:: bash
+
+          ip netns exec <first dhcp namespace> ip addr
+
+       Remember the IP address.
+
+     #. Open a new bash window and connect to a neutron-agent container on a
+        different infrastructure node.
+
+     #. Find the corresponding DHCP server namespace:
+
+        .. code-block:: bash
+
+           ip netns list
+
+     #. Run:
+
+        .. code-block:: bash
+
+           ip netns exec <first dhcp namespace> ping <ip from other dhcp serve>r
+
+        You should see the standard ping output. If not, you may need to
+        perform more advanced troubleshooting by using ``tcpdump``.
+
+.. seealso::
+
+   `tcpdump <https://www.tcpdump.org>`_
+
+.. _octavia-install-manually:
+
+Install the octavia image manually
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If the octavia installation script fails to download the octavia image, you
+can install the image manually by following these steps:
+
+#. Download an octavia amphora image from the `Rackspace images repository
+   <http://rpc-repo.rackspace.com//images/amphora/r14.3.0/>`_.
+
+   This image is built nightly, tested, and uploaded after the test
+   completion.
+
+#. Switch to the OpenStack service tenant.
+#. Ensure the OpenStack project ID (``OS_PROJECT_ID``) is set to the GUID
+   from the service project. By default, the ``octavia`` user belongs to the
+   service tenant.
+#. Install the image by running the following script in the service tenant:
+
+   .. code-block:: bash
+
+      openstack image create --file <image-name> --disk-format qcow2 --tag
+      octavia-amphora-image --private

--- a/kaas-migration/docs/internal/deployment/prepare-provider/rkaas-rpco/lbaas/octavia-prepare.rst
+++ b/kaas-migration/docs/internal/deployment/prepare-provider/rkaas-rpco/lbaas/octavia-prepare.rst
@@ -1,0 +1,135 @@
+.. _octavia-prepare:
+
+========================
+Prepare your environment
+========================
+
+Before deploying octavia, prepare your RPCO environment by creating an
+octavia provider network on each RPCO infrastructure node and configuring
+it according to your requirements. This network ensures communication between
+the RPCO infrastructure nodes and octavia amphorae.
+The following diagram describes the RPCO octavia reference architecture.
+
+.. image:: ./../../../../../figures/d_octavia_network_arch.png
+   :width: 100%
+
+To prepare your environment, follow these steps:
+
+#. Verify that RPCO is operational by launching and destroying a few
+   virtual machines.
+
+#. Assign the octavia VLAN ID to the environment variable:
+
+   .. code-block:: bash
+
+      export VLAN_ID=111
+
+   Octavia automatically configures the network. If the
+   environment needs additional customization, modify the corresponding entries
+   in ``/opt/rpc-octavia/playbooks/default/vars/main.yml``.
+
+   .. note::
+      If you modify the file mentioned above, update ``rpc-octavia``
+      carefully because the values might be lost during the update.
+
+#. Set up the OpenStack octavia container configuration in
+   ``/etc/openstack_deploy/conf.d/octavia.yml.``
+
+     **Example:**
+
+   .. code-block:: yaml
+
+      ---
+
+      octavia-infra_hosts:
+        infra1:
+          ip: 10.0.236.100
+          container_vars:
+            lxc_container_vg_name: vmvg00
+        infra2:
+          ip: 10.0.236.101
+          container_vars:
+            lxc_container_vg_name: vmvg00
+        infra3:
+          ip: 10.0.236.102
+          container_vars:
+            lxc_container_vg_name: vmvg00
+
+#. Verify volume groups, such as ``vmvg00``, by running ``vgscan`` on all
+   RPCO infrastructure nodes:
+
+   .. code-block:: bash
+
+      vgscan
+
+#. Verify IP addresses for each infrastructure node by running the
+   following command:
+
+   .. code-block:: bash
+
+      ip a
+
+.. _octavia-configure-osa:
+
+Configure OpenStack-Ansible
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Configure OSA to deploy OpenStack octavia by adding
+the (CIDR) values and reserving
+``used_ips`` in the ``/etc/openstack_deploy/openstack_user_config.yml`` file.
+
+To configure OSA, follow these steps:
+
+#. Add the new bridge to ``/etc/openstack_deploy/openstack_user_config.yml``
+   along with ``cidr_networks`` and ``used_ips``:
+
+   **Example:**
+
+   .. code-block:: yaml
+
+      cidr_networks:
+      lbaas: 172.29.248.0/22
+
+      used_ips:
+      - "172.29.248.1,172.29.248.50"
+      - "172.29.248.100"
+
+      global_overrides/provider-networks…
+
+      - network:
+          container_bridge: "br-lbaas"
+          container_type: "veth"
+          container_interface: "eth14"
+          host_bind_override: "eth14"
+          ip_from_q: "lbaas"
+          type: "raw"
+          net_name: "lbaas"
+          group_binds:
+              - neutron_linuxbridge_agent
+              - octavia-worker
+              - octavia-housekeeping
+              - octavia-health-manager
+
+#. Configure a new network in octavia by adding and adjusting the following
+   values in ``/etc/openstack_deploy/user_osa_variables_overrides.yml``:
+
+   .. list-table:: **octavia network parameters**
+      :widths: 10 10
+      :header-rows: 1
+
+      * - Parameter
+        - Description
+      * - ``octavia_neutron_management_network_name``
+        - The name of the octavia management network in Neutron.
+          Example: ``lbaas-mgmt``.
+      * - ``octavia_provider_network_name``
+        - The name of the provider network in the system. Example: ``vlan``.
+      * - ``octavia_provider_segmentation_id``
+        - The provider network segmentation ID (VLAN). Example: ``111``.
+      * - ``octavia_container_network_name``
+        - The name used in ``openstack_user_config.yml`` with added
+          ``_address``. Example: ``lbaas_address``.
+      * - ``octavia_provider_network_type``
+        - The type of octavia network provider. Example: ``vlan``.
+      * - ``octavia_management_net_subnet_cidr``
+        - The octavia network CIDR. Example: ``10.0.252.0/22``.

--- a/kaas-migration/docs/internal/deployment/prepare-provider/rkaas-rpco/prepare-rpco.rst
+++ b/kaas-migration/docs/internal/deployment/prepare-provider/rkaas-rpco/prepare-rpco.rst
@@ -1,0 +1,79 @@
+. _prepare-rpco:
+
+================================
+Prepare the OpenStack components
+================================
+
+Before deploying a Kubernetes cluster, complete
+all tasks in this section.
+
+.. _rpco-envs:
+
+Environments
+~~~~~~~~~~~~
+
+If you need to create a new cloud environment, see
+:ref:`create-env`.
+
+.. _rpco-requirements:
+
+Requirements
+~~~~~~~~~~~~
+
+Before you can deploy Rackspace KaaS, verify
+that you have installed and configured all components described in
+:ref:`rkaas-rpco-rpcr-predeployment`.
+
+* This list provides the links to the installation instructions
+  for the major components:
+
+  * OpenStack DNS service (designate)
+     ``kaasctl`` creates DNS records during the installation.
+     Designate is required to create an isolated DNS zone for Kubernetes.
+     For more information, see
+     `Designate Installation Guide <https://pages.github.rackspace.com/rpc-internal/docs-rpc-designate/internal/installing/index.html#designate-ig>`_.
+
+     * For deployments on OpenStack Newton, follow the instructions described
+       in the `Designate documentation
+       <https://github.com/rcbops/rpc-designate/blob/master/INSTALLATION.md>`__.
+       Deployments on OpenStack Queens or later have designate installed
+       as part of the OpenStack deployment.
+
+  * OpenStack Load Balancing service (octavia)
+     Octavia enables Kubernetes workload distribution across Kubernetes master
+     nodes for optimal use of resources and increased service reliability.
+
+    * For deployments on OpenStack Newton, follow the instructions described
+      in :ref:`deploy-lbaas`. Deployments on OpenStack Queens or later
+      have octavia installed as part of the OpenStack deployment.
+
+    * If installing OpenStack octavia in a Newton All-In-One (AIO) environment,
+      follow instructions in `Set up an AIO
+      <https://github.com/rcbops/rpc-octavia#setup-an-aio>`__.
+
+  * Ceph storage cluster
+     Ceph provides persistent block storage for Kubernetes users, as well as
+     for Kubernetes Managed Services internal data.
+     For more information, see
+     `Deploy a Ceph storage cluster <https://pages.github.rackspace.com/rpc-internal/docs-rpc/rpc-ceph-internal/ops/deployments/index.html>`_.
+
+.. _configure-client-machine:
+
+Configure your client machine
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Before you can deploy a Kubernetes cluster, configure your client
+machine to work with Kubernetes. You must have the
+following things in place on your client machine (Mac OSX or Ubuntu):
+
+.. note::
+   When you are deploying KaaS on an RPCO infrastructure node,
+   Docker creates a ``172.17.0.1/16`` bridge by default.
+   You can customize this network if it is already being used on the host by
+   following `these instructions <https://docs.docker.com/v17.09/engine/userguide/networking/default_network/custom-docker0>`__
+   in the Docker documentation.
+
+* `Docker Community Edition <https://www.docker.com/community-edition>`__
+* `kubectl <https://kubernetes.io/docs/tasks/tools/install-kubectl/>`__
+* Access to the Kubernetes
+  `mk8s repository <https://github.com/rackerlabs/kaas>`__.

--- a/kaas-migration/rpc/rpc-o/playbooks/setup_octavia.yml
+++ b/kaas-migration/rpc/rpc-o/playbooks/setup_octavia.yml
@@ -1,0 +1,25 @@
+---
+  # Copyright 2018, Rackspace US, Inc.
+  #
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #     http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
+
+- name: Configure octavia
+  hosts: utility_container[0]
+  tasks: 
+
+    - name: Set Octavia quotas
+      shell: |
+        . {{ ansible_env.HOME }}/openrc
+        openstack quota set --cores "10000" --instances "10000" --ram "10240000" --server-groups "5000" --server-group-members "50" --gigabytes "30000" --volumes "10000" --secgroups "10000" --ports "100000" --secgroup-rules "100000" service
+
+


### PR DESCRIPTION
We are in the process of moving any EOL docs for rpco octavia out of
kaas.