### PR TITLE
rpc-r octavia doc and script migration

### DIFF
--- a/kaas-migration/rpc/rpc-r/octavia/configure_octavia.sh
+++ b/kaas-migration/rpc/rpc-r/octavia/configure_octavia.sh
@@ -1,0 +1,201 @@
+#!/bin/bash
+set -vex
+
+export OCTAVIA_PROJECT_ID="service"
+export OCTAVIA_AMP_PATH="/home/stack/images/amphora-x64-haproxy-centos.qcow2"
+export OCTAVIA_CERT_DIR="/home/stack/octavia-certs"
+export TRIPLEO_CONFIG_DIR="/home/stack/tmp_config_dump/"
+export CONFIG_SAVE="/home/stack/configure_octavia.vars"
+
+if [ "$1" != "override" ] && [ -e $CONFIG_SAVE ]; then
+    echo "Using $CONFIG_SAVE for variables"
+    source $CONFIG_SAVE
+else
+    echo "Proceeding with user environment variables"
+fi
+
+# Check some prereqs
+[ -z "$OVERCLOUD_RC" ] && { echo "Need to set OVERCLOUD_RC with the rc file of the overcloud"; exit 1; }
+[ -z "$STACK_RC" ] && { echo "Need to set STACK_RC with the rc file of the undercloud"; exit 1; }
+[ -z "$TRIPLEO_PLAN_NAME" ] && { echo "Need to set TRIPLEO_PLAN_NAME with the name of the cloud"; exit 1; }
+[ -z "$NETWORK_PREFIX"] && { echo "Need to set NETWORK_PREFIX with the prefix of the controller ips to use, e.g. 172.26.232 on lab 3  "; exit 1; }
+[ -z "$AMP_NETWORK_NAME" ] && { echo "Need to set AMP_NETWORK_NAME with the name of the amphora network, e.g. ext-net"; exit 1; }
+[ -z "$CONTROLLER_REGEX" ] && { echo "Need to set CONTROLLER_REGEX with the regex to determine the controllers inthe undercloud, e.g. export CONTROLLER_REGEX='.*controller.*'"; exit 1; }
+
+#Save the values we used to run this
+if [ ! -e $CONFIG_SAVE ]; then
+    > $CONFIG_SAVE
+    echo "OVERCLOUD_RC=$OVERCLOUD_RC" >> $CONFIG_SAVE
+    echo "STACK_RC=$STACK_RC" >> $CONFIG_SAVE
+    echo "TRIPLEO_PLAN_NAME=$TRIPLEO_PLAN_NAME" >> $CONFIG_SAVE
+    echo "NETWORK_PREFIX=$NETWORK_PREFIX" >> $CONFIG_SAVE
+    echo "AMP_NETWORK_NAME=$AMP_NETWORK_NAME" >> $CONFIG_SAVE
+    echo "CONTROLLER_REGEX=$CONTROLLER_REGEX" >> $CONFIG_SAVE
+fi
+
+
+# source the overcloud RC
+source ${OVERCLOUD_RC}
+if [ ! -z $OS_IDENTITY_API_VERSION ] && [ $OS_IDENTITY_API_VERSION == 3 ] ; then
+    echo "Please use V2 of OvercloudRC file, exiting"
+    exit 1
+fi
+
+
+# Pull images from https://images.rdoproject.org/octavia/queens/
+if [ ! -r "${OCTAVIA_AMP_PATH}" ]; then
+    curl https://images.rdoproject.org/octavia/queens/amphora-x64-haproxy-centos.qcow2 --output ${OCTAVIA_AMP_PATH}
+fi
+
+# Upload image to glance if not alreay uploaded
+# Note: replace image manually
+openstack image list | grep -q 'amphora-x64-haproxy' || \
+openstack image create --container-format bare --disk-format qcow2 \
+--file  ${OCTAVIA_AMP_PATH} \
+--project ${OCTAVIA_PROJECT_ID} --private --tag "octavia-amphora-image" amphora-x64-haproxy \
+&& echo "Skipping image upload since the image already exist."
+
+# Create flavor if not exist
+openstack flavor list --all | grep -q 'm1.amphora' || \
+openstack flavor create --ram 1024 --disk 3  --project ${OCTAVIA_PROJECT_ID} --private m1.amphora
+export OCTAVIA_FLAVOR_ID=$(openstack flavor show m1.amphora -f value -c id)
+
+# Create security group
+openstack security group list | grep -q 'octavia_sec_grp' || \
+(openstack security group create --description  "security group for octavia amphora" --project ${OCTAVIA_PROJECT_ID} octavia_sec_grp; \
+openstack security group rule create --ingress --ethertype=IPv4 --dst-port 9443:9443 --protocol=tcp  octavia_sec_grp)
+# openstack security group rule create --ingress --ethertype=IPv4 --dst-port 22:22 --protocol=tcp  octavia_sec_grp
+export OCTAVIA_SEC_GRP_ID=$(openstack security group  show octavia_sec_grp -f value -c id)
+
+# figure out network-id
+export OCTAVIA_NETWORK_ID=$(openstack network show ${AMP_NETWORK_NAME} -f value -c id)
+[ -z "$OCTAVIA_NETWORK_ID" ] && { echo "Failed to set OCTAVIA_NETWORK_ID using ${AMP_NETWORK_NAME}"; exit 1; }
+
+# Configure quotas
+openstack quota set \
+          --cores "10000" \
+          --instances "10000" \
+          --ram "10240000" \
+          --server-groups "5000" \
+          --server-group-members "50" \
+          --gigabytes "30000" \
+          --volumes "10000" \
+          --secgroups "10000" \
+          --ports "100000" \
+          --secgroup-rules "100000" \
+          service
+
+# Create roles
+openstack role create --or-show load-balancer_observer
+openstack role create --or-show load-balancer_global_observer
+openstack role create --or-show load-balancer_member
+openstack role create --or-show load-balancer_admin
+openstack role create --or-show load-balancer_quota_admin
+
+# Create certs
+mkdir -p ${OCTAVIA_CERT_DIR}
+export OCTAVIA_CERT_PASSWORD=$(openssl rand -base64 32)
+if [ ! -f ${OCTAVIA_CERT_DIR}/passphrase ]; then
+    DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+    # make generated cert valid for 10 years (3652 days)
+    ${DIR}/create_certificates.sh ${OCTAVIA_CERT_DIR} ${DIR}/openssl.conf 3652 ${OCTAVIA_CERT_PASSWORD}
+    echo "${OCTAVIA_CERT_PASSWORD}" > ${OCTAVIA_CERT_DIR}/passphrase
+else
+  export OCTAVIA_CERT_PASSWORD=$(cat ${OCTAVIA_CERT_DIR}/passphrase)
+fi
+
+# figure out keystone endpoints
+export internal_url=$(openstack endpoint show keystone -f value -c internalurl)
+export admin_url=$(openstack endpoint show keystone -f value -c adminurl)
+# this will extract the vip from keystone's publicurl for later use by discarding https and the port
+export vip=$(openstack endpoint show keystone -f value -c publicurl|sed -E "s/https:\/\/(.*):.*/\1/")
+
+source ${STACK_RC}
+#figure out Octavia auth password
+mkdir -p ${TRIPLEO_CONFIG_DIR}
+openstack overcloud config download --name ${TRIPLEO_PLAN_NAME} --config-dir ${TRIPLEO_CONFIG_DIR}
+export OCTAVIA_PWD=$(grep -r "octavia::keystone::auth::password" ${TRIPLEO_CONFIG_DIR} |  rev | cut -d':' -f 1 | rev)
+rm -rf ${TRIPLEO_CONFIG_DIR}
+
+# Configure each controller - the dreaded loop pattern
+export controllers=$(openstack server list --name ${CONTROLLER_REGEX} -f value -c Networks|cut -d '=' -f2|tr "\n" "\n")
+[ -z "$controllers" ] && { echo "Couldn't determine controller hosts. Please check yur regex. Aborting..."; exit 1;}
+
+# Figure out the ips we need to use (assuming they prefix with 172.26.232. )
+# Todo abitrary prefix
+health_ips=""
+for line in $controllers; do
+    health_ips+=$(ssh heat-admin@${line} "set -ex; sudo ip a | grep -v ${vip} | grep -Po 'inet \K${NETWORK_PREFIX}.*?(?=/)'"):5555,
+done
+# remove last comma
+export health_ips=$(echo ${health_ips} | rev | cut -c 2- | rev)
+
+for line in $controllers; do
+echo "Processing controller ${line}"
+# copy certs
+scp -o "StrictHostKeyChecking no" \
+    ${OCTAVIA_CERT_DIR}/ca_02.pem ${OCTAVIA_CERT_DIR}/private/cakey02.pem \
+    ${OCTAVIA_CERT_DIR}/ca_01.pem ${OCTAVIA_CERT_DIR}/client.pem \
+    heat-admin@${line}:/home/heat-admin
+
+# configure
+ssh -o "StrictHostKeyChecking no" heat-admin@${line} <<EOF
+sudo su -
+set -ex
+mkdir -p /etc/pki/ca-trust/extracted/octavia
+mv /home/heat-admin/ca_02.pem /etc/pki/ca-trust/extracted/octavia/
+mv /home/heat-admin/cakey02.pem /etc/pki/ca-trust/extracted/octavia/
+mv /home/heat-admin/ca_01.pem /etc/pki/ca-trust/extracted/octavia/
+mv /home/heat-admin/client.pem /etc/pki/ca-trust/extracted/octavia/
+# We know if we append it at the end oslo.config will take it. So add our  configs
+cat <<-END >>/var/lib/config-data/puppet-generated/octavia/etc/octavia/octavia.conf
+
+# auto generated config $(date)
+[health_manager]
+event_streamer_driver = noop_event_streamer
+controller_ip_port_list=${health_ips}
+bind_ip=0.0.0.0
+[keystone_authtoken]
+auth_uri=${internal_url}
+auth_url=${admin_url}
+project_domain_name = Default
+user_domain_name = Default
+status_update_threads=10 # default 50
+[certificates]
+ca_certificate = /etc/pki/ca-trust/extracted/octavia/ca_02.pem
+ca_private_key = /etc/pki/ca-trust/extracted/octavia/cakey02.pem
+ca_private_key_passphrase = ${OCTAVIA_CERT_PASSWORD}
+[haproxy_amphora]
+client_cert = /etc/pki/ca-trust/extracted/octavia/client.pem
+server_ca = /etc/pki/ca-trust/extracted/octavia/ca_02.pem
+[controller_worker]
+amp_active_retries = 60
+amp_active_wait_sec = 10
+loadbalancer_topology=ACTIVE_STANDBY
+amp_image_tag = octavia-amphora-image
+amp_flavor_id=${OCTAVIA_FLAVOR_ID}
+amp_boot_network_list = ${OCTAVIA_NETWORK_ID}
+amp_secgroup_list = octavia_sec_grp
+client_ca = /etc/pki/ca-trust/extracted/octavia/ca_01.pem
+amp_ssh_access_allowed=false
+[service_auth]
+password=${OCTAVIA_PWD}
+username=octavia
+auth_url=${admin_url}
+project_name=${OCTAVIA_PROJECT_ID}
+project_domain_name = Default
+user_domain_name = Default
+auth_type=password
+[api_settings]
+api_v1_enabled=false
+allow_tls_terminated_listeners=false
+[nova]
+enable_anti_affinity=true
+
+END
+EOF
+ssh -o "StrictHostKeyChecking no" heat-admin@${line} "set -ex; for i in \$(sudo docker ps |grep octavia |awk -F\" \" '{print \$1}'); do sudo docker restart \$i; sleep 3;done"
+
+done
+
+echo "Octavia set up finished!"

--- a/kaas-migration/rpc/rpc-r/octavia/create_certificates.sh
+++ b/kaas-migration/rpc/rpc-r/octavia/create_certificates.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+# USAGE: <certificate directory> <openssl.cnf (example in etc/certificate)
+#Those are certificates for testing will be generated
+#
+#* ca_01.pem is a certificate authority file
+#* server.pem combines a key and a cert from this certificate authority
+#* client.key the client key
+#* client.pem the client certificate
+#
+#You will need to copy them to places the agent_api server/client can find and
+#specify it in the config.
+#
+#Example for client use:
+#
+#curl -k -v --key client.key --cacert ca_01.pem --cert client.pem https://0.0.0.0:9443/
+#
+#
+#Notes:
+#For production use the ca issuing the client certificate and the ca issuing the server cetrificate
+#need to be different so a hacker can't just use the server certificate from a compromised amphora
+#to control all the others.
+#
+#Sources:
+#* https://communities.bmc.com/community/bmcdn/bmc_atrium_and_foundation_technologies/
+#discovery/blog/2014/09/03/the-pulse-create-your-own-personal-ca-with-openssl
+#  This describes how to create a CA and sign requests
+#* https://www.digitalocean.com/community/tutorials/
+#openssl-essentials-working-with-ssl-certificates-private-keys-and-csrs -
+#how to issue csr and much more
+
+## Create CA
+
+# Create directories
+CERT_DIR=$1
+OPEN_SSL_CONF=$2 # etc/certificates/openssl.cnf
+VALIDITY_DAYS=${3:-18250} # defaults to 50 years
+PASSWORD=${4:-foobar}
+
+echo $CERT_DIR
+
+
+mkdir -p $CERT_DIR
+cd $CERT_DIR
+mkdir newcerts private
+chmod 700 private
+
+# prepare files
+touch index.txt
+echo 01 > serial
+
+
+echo "Create the server CA's private and public keypair (2k long)"
+openssl genrsa -passout pass:${PASSWORD} -des3 -out private/cakey02.pem 2048
+
+echo "You will be asked to enter some information about the certificate."
+openssl req -x509 -passin pass:${PASSWORD} -new -nodes -key private/cakey02.pem \
+        -config $OPEN_SSL_CONF \
+        -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=www.example.com" \
+        -days $VALIDITY_DAYS \
+        -out ca_02.pem
+
+
+echo "Here is the certificate"
+openssl x509 -in ca_02.pem -text -noout
+
+echo "Create the client CA's private and public keypair (2k long)"
+openssl genrsa -passout pass:${PASSWORD} -des3 -out private/cakey.pem 2048
+
+echo "You will be asked to enter some information about the certificate."
+openssl req -x509 -passin pass:${PASSWORD} -new -nodes -key private/cakey.pem \
+        -config $OPEN_SSL_CONF \
+        -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=www.example.com" \
+        -days $VALIDITY_DAYS \
+        -out ca_01.pem
+
+
+echo "Here is the certificate"
+openssl x509 -in ca_01.pem -text -noout
+
+
+## Create Server/Client CSR
+echo "Generate a server key and a CSR"
+openssl req \
+       -newkey rsa:2048 -nodes -keyout client.key \
+       -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=www.example.com" \
+       -out client.csr
+
+echo "Sign request"
+openssl ca -passin pass:${PASSWORD} -config $OPEN_SSL_CONF -in client.csr \
+           -days $VALIDITY_DAYS -out client-.pem -batch
+
+echo "Generate single pem client.pem"
+cat client-.pem client.key > client.pem
+
+echo "Note: For production use the ca issuing the client certificate and the ca issuing the server"
+echo "certificate need to be different so a hacker can't just use the server certificate from a"
+echo "compromised amphora to control all the others."
+echo "\nTo use the certificates copy them to the directory specified in the octavia.conf"

--- a/kaas-migration/rpc/rpc-r/octavia/openssl.conf
+++ b/kaas-migration/rpc/rpc-r/octavia/openssl.conf
@@ -1,0 +1,350 @@
+#
+# OpenSSL example configuration file.
+# This is mostly being used for generation of certificate requests.
+#
+
+# This definition stops the following lines choking if HOME isn't
+# defined.
+HOME			= .
+RANDFILE		= $ENV::HOME/.rnd
+
+# Extra OBJECT IDENTIFIER info:
+#oid_file		= $ENV::HOME/.oid
+oid_section		= new_oids
+
+# To use this configuration file with the "-extfile" option of the
+# "openssl x509" utility, name here the section containing the
+# X.509v3 extensions to use:
+# extensions		=
+# (Alternatively, use a configuration file that has only
+# X.509v3 extensions in its main [= default] section.)
+
+[ new_oids ]
+
+# We can add new OIDs in here for use by 'ca', 'req' and 'ts'.
+# Add a simple OID like this:
+# testoid1=1.2.3.4
+# Or use config file substitution like this:
+# testoid2=${testoid1}.5.6
+
+# Policies used by the TSA examples.
+tsa_policy1 = 1.2.3.4.1
+tsa_policy2 = 1.2.3.4.5.6
+tsa_policy3 = 1.2.3.4.5.7
+
+####################################################################
+[ ca ]
+default_ca	= CA_default		# The default ca section
+
+####################################################################
+[ CA_default ]
+
+dir		= ./		# Where everything is kept
+certs		= $dir/certs		# Where the issued certs are kept
+crl_dir		= $dir/crl		# Where the issued crl are kept
+database	= $dir/index.txt	# database index file.
+#unique_subject	= no			# Set to 'no' to allow creation of
+                    # several ctificates with same subject.
+new_certs_dir	= $dir/newcerts		# default place for new certs.
+
+certificate	= $dir/ca_01.pem 	# The CA certificate
+serial		= $dir/serial 		# The current serial number
+crlnumber	= $dir/crlnumber	# the current crl number
+                    # must be commented out to leave a V1 CRL
+crl		= $dir/crl.pem 		# The current CRL
+private_key	= $dir/private/cakey.pem# The private key
+RANDFILE	= $dir/private/.rand	# private random number file
+
+x509_extensions	= usr_cert		# The extensions to add to the cert
+
+# Comment out the following two lines for the "traditional"
+# (and highly broken) format.
+name_opt 	= ca_default		# Subject Name options
+cert_opt 	= ca_default		# Certificate field options
+
+# Extension copying option: use with caution.
+# copy_extensions = copy
+
+# Extensions to add to a CRL. Note: Netscape communicator chokes on V2 CRLs
+# so this is commented out by default to leave a V1 CRL.
+# crlnumber must also be commented out to leave a V1 CRL.
+# crl_extensions	= crl_ext
+
+default_days	= 365			# how long to certify for
+default_crl_days= 30			# how long before next CRL
+default_md	= default		# use public key default MD
+preserve	= no			# keep passed DN ordering
+
+# A few difference way of specifying how similar the request should look
+# For type CA, the listed attributes must be the same, and the optional
+# and supplied fields are just that :-)
+policy		= policy_match
+
+# For the CA policy
+[ policy_match ]
+countryName		= match
+stateOrProvinceName	= match
+organizationName	= match
+organizationalUnitName	= optional
+commonName		= supplied
+emailAddress		= optional
+
+# For the 'anything' policy
+# At this point in time, you must list all acceptable 'object'
+# types.
+[ policy_anything ]
+countryName		= optional
+stateOrProvinceName	= optional
+localityName		= optional
+organizationName	= optional
+organizationalUnitName	= optional
+commonName		= supplied
+emailAddress		= optional
+
+####################################################################
+[ req ]
+default_bits		= 2048
+default_keyfile 	= privkey.pem
+distinguished_name	= req_distinguished_name
+attributes		= req_attributes
+x509_extensions	= v3_ca	# The extensions to add to the self signed cert
+
+# Passwords for private keys if not present they will be prompted for
+# input_password = secret
+# output_password = secret
+
+# This sets a mask for permitted string types. There are several options.
+# default: PrintableString, T61String, BMPString.
+# pkix	 : PrintableString, BMPString (PKIX recommendation before 2004)
+# utf8only: only UTF8Strings (PKIX recommendation after 2004).
+# nombstr : PrintableString, T61String (no BMPStrings or UTF8Strings).
+# MASK:XXXX a literal mask value.
+# WARNING: ancient versions of Netscape crash on BMPStrings or UTF8Strings.
+string_mask = utf8only
+
+# req_extensions = v3_req # The extensions to add to a certificate request
+
+[ req_distinguished_name ]
+countryName			= Country Name (2 letter code)
+countryName_default		= AU
+countryName_min			= 2
+countryName_max			= 2
+
+stateOrProvinceName		= State or Province Name (full name)
+stateOrProvinceName_default	= Some-State
+
+localityName			= Locality Name (eg, city)
+
+0.organizationName		= Organization Name (eg, company)
+0.organizationName_default	= Internet Widgits Pty Ltd
+
+# we can do this but it is not needed normally :-)
+#1.organizationName		= Second Organization Name (eg, company)
+#1.organizationName_default	= World Wide Web Pty Ltd
+
+organizationalUnitName		= Organizational Unit Name (eg, section)
+#organizationalUnitName_default	=
+
+commonName			= Common Name (e.g. server FQDN or YOUR name)
+commonName_max			= 64
+
+emailAddress			= Email Address
+emailAddress_max		= 64
+
+# SET-ex3			= SET extension number 3
+
+[ req_attributes ]
+challengePassword		= A challenge password
+challengePassword_min		= 4
+challengePassword_max		= 20
+
+unstructuredName		= An optional company name
+
+[ usr_cert ]
+
+# These extensions are added when 'ca' signs a request.
+
+# This goes against PKIX guidelines but some CAs do it and some software
+# requires this to avoid interpreting an end user certificate as a CA.
+
+basicConstraints=CA:FALSE
+
+# Here are some examples of the usage of nsCertType. If it is omitted
+# the certificate can be used for anything *except* object signing.
+
+# This is OK for an SSL server.
+# nsCertType			= server
+
+# For an object signing certificate this would be used.
+# nsCertType = objsign
+
+# For normal client use this is typical
+# nsCertType = client, email
+
+# and for everything including object signing:
+# nsCertType = client, email, objsign
+
+# This is typical in keyUsage for a client certificate.
+# keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+
+# This will be displayed in Netscape's comment listbox.
+nsComment			= "OpenSSL Generated Certificate"
+
+# PKIX recommendations harmless if included in all certificates.
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid,issuer
+
+# This stuff is for subjectAltName and issuerAltname.
+# Import the email address.
+# subjectAltName=email:copy
+# An alternative to produce certificates that aren't
+# deprecated according to PKIX.
+# subjectAltName=email:move
+
+# Copy subject details
+# issuerAltName=issuer:copy
+
+#nsCaRevocationUrl		= http://www.domain.dom/ca-crl.pem
+#nsBaseUrl
+#nsRevocationUrl
+#nsRenewalUrl
+#nsCaPolicyUrl
+#nsSslServerName
+
+# This is required for TSA certificates.
+# extendedKeyUsage = critical,timeStamping
+
+[ v3_req ]
+
+# Extensions to add to a certificate request
+
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+
+[ v3_ca ]
+
+
+# Extensions for a typical CA
+
+
+# PKIX recommendation.
+
+subjectKeyIdentifier=hash
+
+authorityKeyIdentifier=keyid:always,issuer
+
+# This is what PKIX recommends but some broken software chokes on critical
+# extensions.
+#basicConstraints = critical,CA:true
+# So we do this instead.
+basicConstraints = CA:true
+
+# Key usage: this is typical for a CA certificate. However since it will
+# prevent it being used as an test self-signed certificate it is best
+# left out by default.
+# keyUsage = cRLSign, keyCertSign
+
+# Some might want this also
+# nsCertType = sslCA, emailCA
+
+# Include email address in subject alt name: another PKIX recommendation
+# subjectAltName=email:copy
+# Copy issuer details
+# issuerAltName=issuer:copy
+
+# DER hex encoding of an extension: beware experts only!
+# obj=DER:02:03
+# Where 'obj' is a standard or added object
+# You can even override a supported extension:
+# basicConstraints= critical, DER:30:03:01:01:FF
+
+[ crl_ext ]
+
+# CRL extensions.
+# Only issuerAltName and authorityKeyIdentifier make any sense in a CRL.
+
+# issuerAltName=issuer:copy
+authorityKeyIdentifier=keyid:always
+
+[ proxy_cert_ext ]
+# These extensions should be added when creating a proxy certificate
+
+# This goes against PKIX guidelines but some CAs do it and some software
+# requires this to avoid interpreting an end user certificate as a CA.
+
+basicConstraints=CA:FALSE
+
+# Here are some examples of the usage of nsCertType. If it is omitted
+# the certificate can be used for anything *except* object signing.
+
+# This is OK for an SSL server.
+# nsCertType			= server
+
+# For an object signing certificate this would be used.
+# nsCertType = objsign
+
+# For normal client use this is typical
+# nsCertType = client, email
+
+# and for everything including object signing:
+# nsCertType = client, email, objsign
+
+# This is typical in keyUsage for a client certificate.
+# keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+
+# This will be displayed in Netscape's comment listbox.
+nsComment			= "OpenSSL Generated Certificate"
+
+# PKIX recommendations harmless if included in all certificates.
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid,issuer
+
+# This stuff is for subjectAltName and issuerAltname.
+# Import the email address.
+# subjectAltName=email:copy
+# An alternative to produce certificates that aren't
+# deprecated according to PKIX.
+# subjectAltName=email:move
+
+# Copy subject details
+# issuerAltName=issuer:copy
+
+#nsCaRevocationUrl		= http://www.domain.dom/ca-crl.pem
+#nsBaseUrl
+#nsRevocationUrl
+#nsRenewalUrl
+#nsCaPolicyUrl
+#nsSslServerName
+
+# This really needs to be in place for it to be a proxy certificate.
+proxyCertInfo=critical,language:id-ppl-anyLanguage,pathlen:3,policy:foo
+
+####################################################################
+[ tsa ]
+
+default_tsa = tsa_config1	# the default TSA section
+
+[ tsa_config1 ]
+
+# These are used by the TSA reply generation only.
+dir		= ./demoCA		# TSA root directory
+serial		= $dir/tsaserial	# The current serial number (mandatory)
+crypto_device	= builtin		# OpenSSL engine to use for signing
+signer_cert	= $dir/tsacert.pem 	# The TSA signing certificate
+                    # (optional)
+certs		= $dir/cacert.pem	# Certificate chain to include in reply
+                    # (optional)
+signer_key	= $dir/private/tsakey.pem # The TSA private key (optional)
+
+default_policy	= tsa_policy1		# Policy if request did not specify it
+                    # (optional)
+other_policies	= tsa_policy2, tsa_policy3	# acceptable policies (optional)
+digests		= md5, sha1		# Acceptable message digests (mandatory)
+accuracy	= secs:1, millisecs:500, microsecs:100	# (optional)
+clock_precision_digits  = 0	# number of digits after dot. (optional)
+ordering		= yes	# Is ordering defined for timestamps?
+                # (optional, default: no)
+tsa_name		= yes	# Must the TSA name be included in the reply?
+                # (optional, default: no)
+ess_cert_id_chain	= no	# Must the ESS cert id chain be included?
+                # (optional, default: no)

--- a/kaas-migration/rpc/rpc-r/octavia/pre-cluster-deploy.sh
+++ b/kaas-migration/rpc/rpc-r/octavia/pre-cluster-deploy.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set +ex
+export octavia_tag=12.0
+
+# Copy the queen version of the puppet template
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+sudo cp ${DIR}/queen_puppet_octavia-health-manager.yaml /usr/share/openstack-tripleo-heat-templates/puppet/services/octavia-health-manager.yaml
+
+# Copy /usr/share/openstack-tripleo-heat-templates/environments/services-docker/octavia.yaml to
+# ~/templates/55-octavia.yaml
+# ~/templates is directory the RPC-R install team made and put install heat templates in
+# for overcloud install paths in the file needs updated to be fully pathed
+
+cp /usr/share/openstack-tripleo-heat-templates/environments/services-docker/octavia.yaml ~/templates/55-octavia.yaml
+
+sed -i -e 's/\.\.\/\.\.\//\/usr\/share\/openstack-tripleo-heat-templates\//g' ~/templates/55-octavia.yaml
+# (optional) remove lbaasv2 from the neutron plugins - uncomment if needed
+# sed -i -e 's/,lbaasv2//g' ~/templates/55-octavia.yaml
+
+# Update ~/templates/01-overcloud_images.yaml with Octavia image information
+grep -v "Octavia" ~/templates/01-overcloud-images.yaml >~/templates/01-overcloud_images.yaml.bak
+cat << EOF >> ~/templates/01-overcloud_images.yaml.bak
+  DockerOctaviaApiImage: registry.access.redhat.com/rhosp12/openstack-octavia-api:${octavia_tag}
+  DockerOctaviaConfigImage: registry.access.redhat.com/rhosp12/openstack-octavia-api:${octavia_tag}
+  DockerOctaviaHealthManagerImage: registry.access.redhat.com/rhosp12/openstack-octavia-health-manager:${octavia_tag}
+  DockerOctaviaHousekeepingImage: registry.access.redhat.com/rhosp12/openstack-octavia-housekeeping:${octavia_tag}
+  DockerOctaviaWorkerImage: registry.access.redhat.com/rhosp12/openstack-octavia-worker:${octavia_tag}
+EOF
+sort ~/templates/01-overcloud_images.yaml.bak |sed  '$ d' | awk 'NR==4 {print "parameter_defaults:"} 1' >  ~/tmp-images.yaml
+
+echo "~/tmp-images.yaml"
+cat ~/tmp-images.yaml
+
+echo "~/templates/01-overcloud-images.yaml"
+cat ~/templates/01-overcloud-images.yaml
+
+read -p "Compare the files. Ok to continue? (Y/N) " -n 1 -r
+echo    # (optional) move to a new line
+if [[ ! $REPLY =~ ^[Yy]$ ]]
+then
+    exit 1
+fi
+
+#  Copy new image yaml into place and make a copy for safekeeping
+cp ~/templates/01-overcloud-images.yaml ~/templates/01-overcloud_images.yaml.bak
+cp ~/tmp-images.yaml ~/templates/01-overcloud-images.yaml
+
+echo "Run install script: ~/scripts/deploy-osp12.sh"

--- a/kaas-migration/rpc/rpc-r/octavia/queen_puppet_octavia-health-manager.yaml
+++ b/kaas-migration/rpc/rpc-r/octavia/queen_puppet_octavia-health-manager.yaml
@@ -1,0 +1,82 @@
+# Copied from https://review.openstack.org/#/c/557731/2/puppet/services/octavia-health-manager.yaml
+
+# force to pike from queens
+heat_template_version: pike
+
+description: >
+  OpenStack Octavia Health Manager service.
+
+parameters:
+  ServiceData:
+    default: {}
+    description: Dictionary packing service data
+    type: json
+  ServiceNetMap:
+    default: {}
+    description: Mapping of service_name -> network name. Typically set
+                 via parameter_defaults in the resource registry.  This
+                 mapping overrides those in ServiceNetMapDefaults.
+    type: json
+  DefaultPasswords:
+    default: {}
+    type: json
+  RoleName:
+    default: ''
+    description: Role name on which the service is applied
+    type: string
+  RoleParameters:
+    default: {}
+    description: Parameters specific to the role
+    type: json
+  EndpointMap:
+    default: {}
+    description: Mapping of service endpoint -> protocol. Typically set
+                 via parameter_defaults in the resource registry.
+    type: json
+  MonitoringSubscriptionOctaviaHealthManager:
+    default: 'overcloud-octavia-health-manager'
+    type: string
+  OctaviaHealthManagerLoggingSource:
+    type: json
+    default:
+      tag: openstack.octavia.health-manager
+      path: /var/log/octavia/health-manager.log
+  OctaviaHeartbeatKey:
+    type: string
+    description: Key to identify heartbeat messages for amphorae.
+    hidden: true
+resources:
+
+  OctaviaBase:
+    type: ./octavia-base.yaml
+    properties:
+      ServiceData: {get_param: ServiceData}
+      ServiceNetMap: {get_param: ServiceNetMap}
+      DefaultPasswords: {get_param: DefaultPasswords}
+      EndpointMap: {get_param: EndpointMap}
+      RoleName: {get_param: RoleName}
+      RoleParameters: {get_param: RoleParameters}
+
+outputs:
+  role_data:
+    description: Role data for the Octavia Health Manager service.
+    value:
+      service_name: octavia_health_manager
+      monitoring_subscription: {get_param: MonitoringSubscriptionOctaviaHealthManager}
+      config_settings:
+        map_merge:
+          - get_attr: [OctaviaBase, role_data, config_settings]
+          - octavia::health_manager::heartbeat_key: {get_param: OctaviaHeartbeatKey}
+            octavia::health_manager::event_streamer_driver: 'queue_event_streamer'
+            tripleo.octavia_api.firewall_rules:
+              '200 octavia health manager interface':
+                proto: udp
+                dport: 5555
+      service_config_settings:
+        fluentd:
+          tripleo_fluentd_groups_octavia_health_manager:
+            - octavia
+          tripleo_fluentd_sources_octavia_health_manager:
+            - {get_param: OctaviaHealthManagerLoggingSource}
+      step_config: |
+        include tripleo::profile::base::octavia::health_manager


### PR DESCRIPTION
We are working on moving the octavia install docs and scripts
out of the kaas repo. Older docs and scripts were moved into
this repo using the same directory structure as kaas. The rpc-r
docs for osp 13 have been updated to include the octavia config
steps.

Working out of git issue: rcbops/rpc-prodeng#7